### PR TITLE
1: User library

### DIFF
--- a/src/botData/__init__.py
+++ b/src/botData/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["operations", "settings", "users"]

--- a/src/botData/dataObjects.py
+++ b/src/botData/dataObjects.py
@@ -1,0 +1,1040 @@
+# A singular file containing ALL data objects used by the bot.
+# Mainly to avoid circular references by things that depend on each other; but not always part of the same module.
+
+from __future__ import annotations
+
+from enum import Enum
+from discord import Member, Message, Guild
+from dataclasses import dataclass, field
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+import botData.settings as Settings
+import botUtils
+from auraxium.ps2 import Character as PS2Character
+from auraxium.ps2 import MapRegion as PS2Facility
+from auraxium.ps2 import OutfitMember as PS2OutfitMember
+import pickle
+
+
+# # # # #  SETTINGS RELATED
+
+@dataclass(frozen=True)
+class BotFeatures:
+	"""
+	# BOT FEATURES
+	A class pertaining to overall features, allowing things to be disabled more gracefully (since some items may tie into one another)
+	"""
+	BotAdmin:bool
+	NewUser: bool
+	UserLibrary: bool
+	userLibraryInboxSystem: bool
+	userLibraryInboxAdmin: bool
+	UserLibraryFun: bool
+	Operations: bool
+	chatUtility: bool
+	UserRoles: bool
+	ForFunCog: bool
+
+
+# # # # USER LIBRARY
+
+
+@dataclass
+class SleeperRules:
+	"""# SLEEPER RULES
+	Rules to determine when a user is asleep/inactive"""
+	bIsEnabled:bool
+	"""Set as false to disable."""
+
+	bSelfOutfitOnly: bool
+	"""# Self Outfit Only:
+	If true, only members with the `Roles.promotion` role are checked."""
+
+	bInbRecentEvent:bool
+	"""# In recent event:
+	Set to true to check if the user was in a recent event.
+	"""
+
+	mostRecentEvent:relativedelta
+	"""# Most recent event:
+	The offset by which to test the most recent event."""
+
+
+	def __repr__(self) -> str:
+		vstring = f"	> Sleeper Rules {self.bIsEnabled}  (Only drunken dogs: {self.bSelfOutfitOnly})\n"
+		vstring += f"	>> RULE: In most recent event: {self.bInbRecentEvent} | {self.mostRecentEvent}\n"
+
+		return vstring
+
+
+@dataclass
+class UserSettings:
+	"""
+	# USER SETTINGS
+	Settings pertaining to the User data object.
+	"""
+	bLockPS2Char = False
+	bLockAbout = False
+	bTrackHistory = True
+
+	def __repr__(self) -> str:
+		vStr = f"	> Lock PS2 Character:	{self.bLockPS2Char}\n"
+		vStr += f"	> Lock About:		{self.bLockAbout}\n"
+		vStr += f"	> Track History:	{self.bTrackHistory}\n"
+
+		return vStr
+
+
+class EntryRetention(Enum):
+	"""# ENTRY RETENTION
+	Enum for the entry load setting.
+	- `always loaded` Entries are always loaded in memory.
+	- `unload after` Entries are unloaded afer x minutes.
+	- `when needed` Entries are loaded/saved only when needed.
+	"""
+	alwaysLoaded = 0
+	unloadAfter = 10
+	whenNeeded = 20
+
+
+@dataclass(frozen=True)
+class AutoPromoteRule():
+	"""
+	# AUTO PROMOTE RULE
+	Contains values pertaining to the rules a user must meet before auto-promotion from recruit.
+
+	This should be obtained from `botData.settings`!
+	"""
+	# Attended Minimum Events: the number of events a user must participate in
+	bAttendedMinimumEvents: bool
+	bEventsMustBePS2: bool
+	minimumEvents: int
+
+	# Length of time a user must be in the outfit.
+	bInOutfitForDuration: bool
+	outfitDuration: datetime.time
+
+	# Length of time a user must have been in the discord server.
+	bInDiscordForDuration: bool
+	discordDuration: datetime.time
+
+
+	def __repr__(self) -> str:
+		vString = f"\n		> Attend Minimum Events: {self.bAttendedMinimumEvents} ({self.minimumEvents})\n"
+		vString += f"		> Events must be Planetside 2: {self.bEventsMustBePS2}\n"
+		vString += f"		> In Outfit for Duration: {self.bInOutfitForDuration} | {self.outfitDuration}\n"
+		vString += f"		> In Discord for Duration: {self.bInDiscordForDuration} | {self.discordDuration}\n"
+
+		return vString
+
+
+
+@dataclass
+class UserInboxItem:
+	"""# USER INBOX ITEM
+	Data for an inbox item, sent by administrators and some bot features.
+	"""
+	# Date/Time the inbox item was sent.
+	date: datetime
+	# Title of the item.
+	title: str
+	# Message of the item.
+	message:str
+	# If sent by an admin command, this is true.
+	bIsWarning:bool
+	# If sent by an admin for a message, this is a snip of the message for context.
+	adminContext:str
+
+
+
+
+class LibraryViewPage(Enum):
+	"""
+	# LIBRARY VIEW: PAGE
+	Enum to mark the current page being viewed.
+	"""
+	general = 0
+	ps2Info = 10
+	sessions = 20
+	individualSession = 25
+	inbox = 30
+
+
+
+
+@dataclass
+class User:
+	"""
+	# USER (UserLibrary)
+	Data object representing a user on the discord.  
+	
+	Contains their planetside2 character information, and tracked event sessions.
+
+	NOTE: DO NOT adjust `__version`!
+	"""
+	__version = -1
+
+	discordID: int = -1
+	"""Used to get the member from discord."""
+
+	ps2ID: int = -1
+	ps2Name: str = ""
+	ps2Outfit: str = ""
+	ps2OutfitRank: str = ""
+	ps2OutfitJoinDate: datetime = None
+
+	bIsRecruit = False
+	"""Used alongside auto-promote; this is set by NewUser or manually."""
+
+	sessions :list[Session] = field(default_factory=list)
+	"""List of saved sessions, if enabled."""
+
+	lastSession:datetime = None
+	"""Last session: saved to allow checking the date of the last session in the event a users session saving is disabled."""
+	
+	eventsAttended = 0
+	""" Number of events the user has attended/been marked attending for."""
+
+	eventsMissed = 0
+	"""Number of events the user signed up to, but did not attend."""
+	
+	birthday:datetime = None
+
+	aboutMe = ""
+	"""User provided 'about me' text."""
+
+	specialAbout = ""
+	"""Special text loaded from a separate file, editable only by admins."""
+
+	topQuotes: list[str] = field(default_factory=list)
+	"""List of top reacted quotes, if enabled."""
+
+	inbox:list[UserInboxItem] = field(default_factory=list)
+	"""Users inbox, if enabled."""
+
+	settings: UserSettings = field(default_factory=UserSettings)
+	"""Settings for this users library entry."""
+
+	lastAccessed: datetime = None
+	"""Datetime of last accessed, set whenever the entry is loaded or saved."""
+	
+	bKeepLoaded:bool = False
+	"""	Set to true during events.
+	Save/Load will always revert this to False """
+
+	bRecruitRequestedPromotion = False
+	"""Set to true when a recruit has manually requested promotion via library viewer."""
+
+
+@dataclass
+class NewUserData:
+	"""# NEW USER DATA:
+	Minimal dataclass to hold data about a new user.
+	"""
+	userObj : Member = None
+	joinMessage : Message = None
+	rulesMsg : Message = None
+	ps2CharObj: PS2Character = None
+	ps2CharID : int = -1
+	ps2CharName : str = ""
+	ps2OutfitName: str = ""
+	ps2OutfitAlias: str = ""
+	ps2OutfitCharObj: PS2OutfitMember = None
+	bIsRecruit = False
+
+
+	############################################################################
+# OP COMMANDER
+class CommanderStatus(Enum):
+	"""
+	# COMMANDER STATUS
+	Enum to contain the status of a commander.  
+	
+	### Values are numerical.
+	"""
+	Init = -10 
+	"""Init: Commander has been created."""
+	Standby = 0
+	"""Standby: Commander has been set up and waiting."""
+	WarmingUp = 10 
+	"""Warming Up: Updates the commander post with connections modal."""
+	GracePeriod = 15 
+	"""Grace Period: The time just before an event properly starts, for event attendance."""
+	Started = 20
+	"""Started: Ops has been started (either manually or by bot.)"""
+	Debrief = 30 
+	"""Debrief: Pre-End stage, users are given a reactionary View to provide feedback"""
+	Ended = 40
+	"""Ended: User has ended Ops,  auto-cleanup."""
+
+
+
+class PS2EventAttended(Enum):
+	"""# PS2 EVENT ATTENDED:
+	An enum with values to denote when a participant of an event is marked attended.
+	This is used synonymously with the UserLibrary & session saving.
+
+	NOTE: When evaluating DiscordVC, the user must be in an event channel.
+
+	A user who fails the requirements set by this enum are marked as non attending.
+	`NeverCheck`: marks anyone who signed up as attended.
+	"""
+	NeverCheck = 0
+	InGameOnly = 10
+	InDiscordVCOnly = 20
+	InGameAndDiscordVC = 30
+
+
+@dataclass
+class PS2EventTotals:
+	"""# PS2 EVENT TOTALS
+	Dataclass that holds stat totals.
+	Used to prevent unnessecery iteration calculations while event is running.
+	The event totals are added to this stat object at the same time as the current event point & user session stats.
+	"""
+	eventKDA:PS2SessionKDA = None
+	facilityFeed:list[str] = field(default_factory=list)
+	facilitiesCaptured:int = 0
+	facilitiesDefended:int = 0
+
+
+# SESSION SUB OBJECTS
+@dataclass
+class PS2SessionKDA:
+	""" # PS2 SESSION: KILLS ASSISTS AND DEATHS
+	Data object containing KDA information for a session.
+
+	NOTE: DO NOT adjust `__version`
+	"""
+	__version:int = -1
+
+	kills:int = 0
+	killedAllies:int = 0
+	killedSquad:int = 0
+	assists:int = 0
+	vehiclesDestroyed:int = 0
+
+	deathTotal:int = 0
+	deathByEnemies:int = 0
+	deathByAllies:int = 0
+	deathBySquad:int = 0
+	deathBySuicide: int = 0
+
+
+@dataclass
+class PS2SessionEngineer:
+	"""
+	# PS2 SESSION : ENGINEER SPECIFIC DATA
+
+	Role specific data for Engineers.
+
+	NOTE: DO NOT adjust `__version`.
+	"""
+	__version:int = -1
+
+	repairScore:int = 0
+	resupplyScore:int = 0
+
+
+@dataclass
+class PS2SessionMedic:
+	"""
+	# PS2 SESSION : MEDIC SPECIFIC DATA
+
+	Role specific data for medics.
+
+	NOTE: DO NOT adjust `__version`.
+	"""
+	__version:int = -1
+	revives:int = 0
+	heals:int = 0
+
+
+@dataclass
+class Session:
+	"""
+	# SESSION
+	Dataclass that represents a single user session.
+	
+	NOTE: KDA, MedicData, and EngineerData must be created and set for the first instance.
+	This ensures no uneeded data is saved.
+
+	NOTE: DO NOT adjust version.
+	Version will be used to ensure any changes to the Session Data object will be detectable and old data can still be dealt with.
+	EG: `if __version < current: User.sessions.remove(Session)`
+	"""
+	eventName: str = ""
+	bIsPS2Event: bool = True
+	date: datetime = None
+	duration: float = 0 # Set by commander, currently configured to be in hours.
+	kda:PS2SessionKDA = None
+	medicData:PS2SessionMedic = None
+	engineerData:PS2SessionEngineer = None
+	score: int = 0
+	funEvents:list[str] = field(default_factory=list)
+	__version:int = -1
+
+
+
+@dataclass
+class Participant:
+	"""
+	# PARTICIPANT
+	Dataclass containing a reference to a `discord.Member`, and a `userLibrary.User` for a participant.
+	"""
+	# OBJECT REFERENCES
+	discordUser : Member = None
+	libraryEntry : User = None
+	ps2CharID : int = -1
+	"""Used regardless of user library setting.  If library is enabled, this value is obtained from there when applicable."""
+	userSession : Session = None
+
+	# DATA
+	discordID : int = 0
+	bAttended: bool = False
+	bWasLate: bool = False
+	bPS2Online : bool = False # Set to true by aurax event.
+	bInEventChannel: bool = False # Set to true when a user is in one of the event channels.
+	lastCheckedName : str = "" # Last Checked name: skips searching for a PS2 character if this is the same.
+
+	def __repr__(self) -> str:
+		vStr = f"\nPARTICIPANT: {self.discordID}\n"
+		if self.libraryEntry == None:
+			vStr += f"	LIBRARY ENTRY NOT SET"
+		else:
+			vStr += f"	LIBRARY PS2 NAME: {self.libraryEntry.ps2Name}"
+		if self.discordUser == None:
+			vStr += f"	DISCORD USER UNSET"
+		else:
+			vStr += f"	DISCORD USER SET :{self.discordUser.display_name}"
+
+		return vStr
+
+
+
+	def SaveParticipant(self):
+		"""
+		# SAVE PARTICIPANT
+		Saves the participant libEntry data to file.
+		"""
+		dataFile = f"{Settings.Directories.userLibrary}{self.discordID}.bin"
+		lockFile = botUtils.FilesAndFolders.GetLockPathGeneric(dataFile)
+
+		botUtils.FilesAndFolders.GetLock(lockFile)
+		try:
+			with open(dataFile, "wb") as vFile:
+				self.libraryEntry = pickle.dump(self.libraryEntry, vFile)
+			botUtils.FilesAndFolders.ReleaseLock(lockFile)
+		except pickle.PickleError as vError:
+			botUtils.BotPrinter.LogErrorExc("Failed to save user library entry.", vError)
+			botUtils.FilesAndFolders.ReleaseLock(lockFile)
+
+
+
+@dataclass
+class OpFeedback:
+	"""
+	# OPS FEEDBACK
+	Class containing variable lists which hold user submitted feedback
+	"""
+	userID:list[str] = field(default_factory=list) # Saved to allow users to edit their feedback.
+	generic:list[str] = field(default_factory=list)
+	forSquadmates:list[str] = field(default_factory=list)
+	forSquadLead:list[str] = field(default_factory=list)
+	forPlatLead:list[str] = field(default_factory=list)
+
+	def SaveToFile(self, p_eventName:str):
+		"""
+		# SAVE TO FILE
+
+		Saves the feedback to a file, using the event name provided.
+
+		## Returns: 
+		The filepath of the saved file.
+		Or "" if saving failed.
+		"""
+
+		# Save feedback to file.
+		filePath = f"{Settings.Directories.tempDir}{p_eventName}_feedback.txt"
+		try:
+			with open(filePath, "w") as vFile:
+				vFile.write("GENERAL FEEDBACK\n")
+				for line in self.generic:
+					if line != "" or "\n":
+						vFile.write(f"{line}\n\n")
+
+				vFile.write("\n\nTO SQUADMATES\n")
+				for line in self.forSquadmates:
+					if line != "" or "\n":
+						vFile.write(f"{line}\n\n")
+
+				vFile.write("\n\nTO SQUAD LEAD\n")
+				for line in self.forSquadLead:
+					if line != "" or "\n":
+						vFile.write(f"{line}\n\n")
+
+				vFile.write("\n\nTO PLATOON LEAD\n")
+				for line in self.forPlatLead:
+					if line != "" or "\n":
+						vFile.write(f"{line}\n\n")
+			
+			return filePath 
+
+		except OSError:
+			botUtils.BotPrinter.LogError("Unable to save a the file!")
+			return ""
+
+
+
+
+@dataclass(frozen=True)
+class EventID:
+	"""
+	# EVENT IDs
+	Matches event IDs to human readable variable names.
+	Where an event has multiple sub-events, the variable is a list for iteration purposes.
+
+	All events included are for squad only and thus will not track general events. 
+		eg: 'med_heal' only counts heals to squad-members, not blueberries.
+	"""
+	med_heal = 4
+	med_revive = 53
+
+	eng_maxRepair = 142
+	eng_vehicleRepair = [28, 129, 132, 133, 134, 138, 140, 141, 302, 505, 656]
+	eng_resupply = 55
+
+	kill = 1
+	killAssist = 2
+
+
+
+
+@dataclass
+class FacilityData:
+	"""# FACILITY DATA
+	Information pertaining to a facility defense or capture.
+	"""
+	facilityID:int = 0
+	timestamp:datetime = None
+	facilityObj:PS2Facility = None
+	participants:int = 0
+
+
+
+@dataclass
+class EventPoint():
+	"""
+	# EVENT POINT
+	A singular point during an event, used to plot graphs.
+
+	These are updated individually to user statistics.
+	"""
+	timestamp: datetime
+	activeParticipants: int
+
+	captured:int = 0
+	defended:int = 0
+
+	deaths: int = 0
+	kills: int = 0
+
+	revives: int = 0
+	repairs: int = 0
+
+
+@dataclass
+class ForFunVehicleDeath:
+	"""# FOR FUN VEHICLE DEATH
+	Small data object for vehicle death for-fun events: 
+	Used to ensure only one event is broadcast since the DEATH trigger will be called for each participants death.
+	"""
+	# Killer/Driver Vehicle ID: Probably redundant, but here anyway.
+	driverVehicleID:int = -1
+	# Killer/Driver Character ID: PS2 Character ID of the killer.
+	driverCharID: int = -1
+
+	# For discord purposes: Killer and Killed mentions.
+	driverMention:str = ""
+	killedMentions:str = ""
+
+	# Message: the randomly message chosen randomly by the OpsEventTracker
+	message:str = ""
+
+	# Has Set Schedule Task: Should be set to true on first call, creates a delayed task on the Commander to post a message.
+	# Delay is to ensure all (or most of) the users involved has their death event register.
+	bHasSetSchedTask = False
+
+
+	#############################################################
+# OPERATIONS SIGNUP
+
+@dataclass
+class SchedulerOpInfo:
+	"""# OP INFO: 
+	
+	A miniture operation info dataclass used soley for parsing the schedule.
+	"""
+	matchingOp: str = ""
+	eventName: str = ""
+	date: datetime = None
+	managingUser:str = ""
+	bCanPost:bool = False
+
+
+class OpsStatus(Enum):
+	"""
+	# OPS STATUS
+	
+	Defines the current status of an Operation.
+	"""
+	editing = -1 # Ops is being edited, users can't signup.
+	open = 1 # Open to signups.
+	prestart = 10 # set when pre-op setup starts.
+	started = 20 # Ops started.
+	debriefing = 30 # Probably redundant. 
+
+
+@dataclass
+class OperationOptions:
+	"""
+	# OPERATION OPTIONS
+
+	Options, typically altered via use of arguments, to determine behaviour of the ops.
+	"""
+	bUseReserve : bool = True # Only enable built in RESERVE if true.
+	bUseCompact : bool = False # If True, does not show a member list for each role.
+	bAutoStart : bool = True # If false, someone must use `/commander [OpData]` to start the commander.
+	bUseSoberdogsFeedback : bool = False # If true, debriefing opens a new forum thread and send the feedback message there.
+	bIsPS2Event : bool = True # If false, treats this event as a non-PS2 event.
+
+
+@dataclass
+class OpRoleData:
+	"""
+	# OP ROLE DATA
+	
+	Data pertaining to an individual role on an Operation
+	"""
+	players : list = field(default_factory=list) #User IDs
+	roleName : str = ""
+	roleIcon : str = ""
+	maxPositions : int = 0
+
+	def GetRoleName(self):
+		"""
+		# GET ROLE NAME:
+		Returns a precompiled string containing the icon if present, and the min/max or just current count, depending on configuration.
+		"""
+		vRolename = ""
+
+		# Icon
+		if self.roleIcon != "-":
+			vRolename = f"{self.roleIcon}{self.roleName}"
+		else:
+			vRolename = self.roleName
+
+		# Signed Up/Positions:
+		if self.maxPositions > 0:
+			vRolename += f" ({len(self.players)}/{self.maxPositions})"
+		else:
+			vRolename += f" ({len(self.players)})"
+
+		return vRolename
+
+
+
+@dataclass
+class OperationData:
+	"""
+	# OPERATION DATA
+	Data pertaining to an Operation/Event.
+	Includes a list of OpRoleData objects, which hold information specific to individual roles.
+	"""
+
+	# Op Details:
+	roles : list[OpRoleData] = field(default_factory=list) # List of OpRoleData objects
+	reserves : list = field(default_factory=list) # Since there's no need for special data for reserves, they just have a simple UserID list.
+	name : str = ""
+	fileName: str = ""
+	date : datetime = datetime.now()
+	description : str = ""
+	customMessage : str = ""
+	managedBy:str = ""
+	pingables : list[str] = field(default_factory=list) # roles to mention/ping in relation to this ops.
+
+	# Backend variables
+	messageID : str = "" 
+	status : OpsStatus = OpsStatus.open
+	targetChannel: str = ""
+	options: OperationOptions = OperationOptions()
+	jumpURL: str = ""
+
+	# Factory fields
+	voiceChannels: list[str] = field(default_factory=list)
+	arguments: list[str] = field(default_factory=list)
+
+
+	def GenerateFileName(self):
+		"""
+		# GENERATE FILE NAME
+		Generates a filename using the operation name, and the date (opName_y-m-d_h-m).
+		File name does not include the extension!
+		
+		NOTE: Sets the fileName variable with the result.  
+			It is not returned.
+		"""
+		self.fileName = f"{self.name}_{self.date.year}-{self.date.month}-{self.date.day}_{self.date.hour}-{self.date.minute}"
+		
+		botUtils.BotPrinter.Debug(f"Filename for Op {self.name} generated: {self.fileName}")
+
+
+	def GetFullFilePath(self):
+		"""
+		# GET FULL FILE PATH (LIVE ONLY)
+		Convenience function to get the filepath of the live event.
+		"""
+		return f"{Settings.Directories.liveOpsDir}{self.fileName}.bin"
+
+
+	def PlayerInOps(self, p_playerID:int):
+		"""
+		# PLAYER IN OPS
+		### RETURN: 
+		`str`- "" when not in ops, else string of role name.
+
+		Convenience function to avoid repetition.
+		"""
+		if self.options.bUseReserve:
+			if p_playerID in self.reserves:
+				return "Reserve"
+
+		for role in self.roles:
+			if p_playerID in role.players:
+				return role.roleName
+
+		return ""
+
+
+
+	def ArgStringToList(self, p_string:str, p_deliminator:str = " "):
+		"""
+		# ARGUMENT STRING TO LIST
+		Converts an argument string to a list, then runs Parse.
+		A deliminator may be specified, uses ' ' by default.
+		"""
+		newArgList = p_string.split(p_deliminator)
+
+		if newArgList != None:
+			botUtils.BotPrinter.Debug(f"Setting op argument list: {newArgList}")
+			self.arguments = newArgList
+
+			botUtils.BotPrinter.Debug(f"OpData Argument list: {self.arguments}")
+
+			self.ParseArguments()
+
+		else:
+			botUtils.BotPrinter.Debug("No arguments.")
+
+
+	def ParseArguments(self):
+		"""
+		# PARSE ARGUMENTS
+		Parses the arguments given and sets their respective options.
+		"""
+		botUtils.BotPrinter.Debug(f"Parsing opdata arguments: {self.arguments}")
+		argument:str
+		for argument in self.arguments:
+
+			argInLower = argument.lower().strip()
+
+			# TOGGLE VIEW TYPE
+			if argInLower == "compact":
+				self.options.bUseCompact = True
+				botUtils.BotPrinter.Debug(f"Using viewmode: Compact for {self.name}")
+				continue
+
+			elif argInLower == "fullview":
+				self.options.bUseCompact = False
+				botUtils.BotPrinter.Debug(f"Using viewmode: Full for {self.name}")
+				continue
+
+
+			# TOGGLE RESERVE
+			if argInLower == "noreserve":
+				self.options.bUseReserve = False
+				botUtils.BotPrinter.Debug(f"Setting Reserves: OFF for {self.name}")
+				continue
+
+			elif argInLower == "reserveon":
+				self.options.bUseReserve = True
+				botUtils.BotPrinter.Debug(f"Setting Reserves: ON for {self.name}")
+				continue
+
+
+			# TOGGLE AUTO START
+			if argInLower == "noauto":
+				self.options.bAutoStart = False
+				botUtils.BotPrinter.Debug(f"Setting Automatic Start: OFF for {self.name}")
+				continue
+
+			elif argInLower == "autostart":
+				self.options.bAutoStart = True
+				botUtils.BotPrinter.Debug(f"Setting Automatic Start: ON for {self.name}")
+				continue
+
+
+			# TOGGLE SOBERDOGS FEEDBACK
+			if argInLower == "nofeedback":
+				self.options.bUseSoberdogsFeedback = False
+				botUtils.BotPrinter.Debug(f"Setting Soberdogs Feedback: OFF for {self.name}")
+				continue
+
+			elif argInLower == "soberfeedback":
+				self.options.bUseSoberdogsFeedback = True
+				botUtils.BotPrinter.Debug(f"Setting Soberdogs Feedback: ON for {self.name}")
+				continue
+
+
+			# TOGGLE PS2 EVENT
+			if argInLower == "ps2event":
+				self.options.bIsPS2Event = True
+				botUtils.BotPrinter.Debug(f"Setting PS2 Event: ON for {self.name}")
+				continue
+
+			elif argInLower == "notps2":
+				self.options.bIsPS2Event = False
+				botUtils.BotPrinter.Debug(f"Setting PS2 Event: OFF for {self.name}")
+				continue
+
+
+	def GetOptionsAsStr(self):
+		"""
+		# GET OPTIONS AS STRING
+
+		Returns a condensed formatted version of the options as a string, eg:
+		AS:E|UR:E|UC:D|SDF:D
+		"""
+		vOptsStr = "AS:"
+		if self.options.bAutoStart:
+			vOptsStr += "E"
+		else: vOptsStr += "D"
+
+
+		vOptsStr += "|UR:"
+		if self.options.bUseReserve:
+			vOptsStr += "E"
+		else: vOptsStr += "D"
+
+
+		vOptsStr += "|UC:"
+		if self.options.bUseCompact:
+			vOptsStr += "E"
+		else: vOptsStr += "D"
+
+
+		vOptsStr += "|SDF:"
+		if self.options.bUseSoberdogsFeedback:
+			vOptsStr += "E"
+		else: vOptsStr += "D"
+
+
+		vOptsStr += "|PSE:"
+		if self.options.bIsPS2Event:
+			vOptsStr += "E"
+		else: vOptsStr += "D" 
+
+		return vOptsStr
+
+
+	def GetParticipantIDs(self) -> list[int]:
+		"""
+		# GET PARTICIPANT IDS
+		Returns all roles participants (Discord IDs), including reserve if enabled in a list.
+		"""
+		vIDList = [playerID for role in self.roles if self.roles.__len__() != 0 for playerID in role.players]
+		vIDList = vIDList + self.reserves
+		
+		botUtils.BotPrinter.Debug(f"PARTICIPANT IDS: {vIDList}")
+
+		return vIDList
+
+
+
+	def GetPingables(self, p_guild:Guild)-> str:
+		"""# GET PINGABLES:
+		Returns a string of all role pingables.
+		Requires a guild reference to obtain the roles from."""
+
+		roleMentions = [f"{role.mention} " for role in p_guild.roles if role.name in self.pingables ]
+		outputString = ""
+		for role in roleMentions:
+			outputString += f"{role} "
+
+		return outputString
+
+
+
+	def __repr__(self) -> str:
+		vOutputStr = "	OPERATION DATA\n"
+		vOutputStr += f"	-> Name|FileName: {self.name} | {self.fileName}\n"
+		vOutputStr += f"	-> Date: {self.date}\n"
+		vOutputStr += f"	-> Description: {self.description}\n"
+		vOutputStr += f"	-> Additional Info: {self.customMessage}\n"
+		vOutputStr += f"	-> Message ID: {self.messageID}\n"
+		vOutputStr += f"	-> Arguments: {self.arguments}\n"
+		vOutputStr += f"	-> Status: {self.status.name}\n"
+		vOutputStr += f"	-> VoiceChannels: {self.voiceChannels}\n"
+		vOutputStr += f"	-> Reserves: {self.reserves}\n"
+		vOutputStr += f"	-> Options: {self.options}\n"
+		vOutputStr += f"	-> Roles: {self.roles}\n"
+		return vOutputStr
+
+
+@dataclass(frozen=True)
+class DefaultChannels:
+	"""
+	# DEFAULT CHANNELS
+	Name of channels used during Operations.
+	"""
+	# Text chanels created for every Op
+	textChannels:list[str]
+	# Op Commander Channel: Name of the channel used for the Ops Commander
+	opCommander:str
+	# Notification Channel: Name of channel used to send op auto alerts and interactive debrief messages.
+	notifChannel:str
+	# Standby channel- the channel(name) users are moved into if they are connected during Ops soft start
+	standByChannel:str
+	# Persistent Voice channels are channels that are ALWAYS created for every operation
+	persistentVoice:list[str]
+	# If voice channels are not specified in the ops data, these are used instead
+	voiceChannels:list[str]
+
+	def __repr__(self) -> str:
+		vString = "\n"
+		vString += f"		> Text Channels: {self.textChannels}\n"
+		vString += f"		> Voice Channels: {self.voiceChannels}\n"
+		vString += f"		> Persistent Voice: {self.persistentVoice}\n"
+		vString += f"		> Commander Channel: {self.opCommander}\n"
+		vString += f"		> Notifications Channel: {self.notifChannel}\n"
+		vString += f"		> Standby Channel: {self.standByChannel}\n"
+		return vString
+
+#################################
+
+dataclass(frozen=True)
+class ForFunData:
+	"""# FOR FUN DATA
+	Contains data objects relating to 'For Fun'
+	
+	Strings may contian the following special replaceable substrings:
+	`_USER`: The user the string is typically about.
+	`_USERBY`: If the string is caused by another user, this is included; variable name is affixed with "By".
+	`_VEHICLE`: If the string relates to a flight death, this should be replaced with the offending vehicle (Valk/Galaxy/Lib?)
+	`_FLIGHTDEATHREASON` - Specific to morning greetings, for a little extra fun. :)
+	"""
+
+	# Party Death Bus: intended for the user library fun entries.
+	partyBusDeath = [
+		"Bought a one way ticket to Death Valley on _USER's bus.",
+		"Met an unfortunate ending when _USER's bus spontaneously exploded.",
+		"Received a lesson in 'how not to drive' by _USER.",
+	]
+	
+	# Party Bus Death By: when a user(s) is killed by being in someone elses sunderer.
+	partyBusDeathBy =[
+		"_USER took a one way trip to DeathVille on a party bus driven by _USERBY!",
+		"_USERBY should return their bus drivers license! They killed _USER!",
+		"Attention _USER, your bus to Alive City took an unfortunate detour to Death Valley, on account of _USERBY",
+		"_USERBY forgot how to drive.  _USER found that out the hard way.",
+		"_USER made the *grave* mistake of getting into _USERBY's party bus.",
+		"Attention _USERBY!\nYou have been enrolled on a Sunderer driving course, courtesy of _USER",
+		"_USERBY forgot that wheels are supposed to touch the ground. __USER had to make use of the emergency bucket.",
+		"Dear _USERBY.\nI would like to inform you that sunderers do not fly, nor are their wheels supposed to aim upwards.\n\nSincerely, _USER",
+	]
+
+
+	flightDeath =[
+		"Met an unfortunate end when _USER's _VEHICLE spontaneously exploded.",
+		"Waiting for a bonus check after _USER crashed their _VEHICLE... again.",
+		"Died to _USER's inability to fly a skybus.",
+		"Got in _USER's _VEHICLE.  That was a *grave* mistake.",
+		"Received a lesson in 'How not to fly' by _USER."
+	]
+	#################
+	"""# FLIGHT DEATH:
+	Intended for user library entries (for fun).
+	When the player has been killed by a squadmate's (`_USER`) dying vehicle"""
+
+
+	flightDeathBy = [
+		"_USER just went splat after _USERBY forgot which way is up.",
+		"_USER is awaiting a bonus check after _USERBY crashed their _VEHICLE.\n\n**Again.**",
+		"_USERBY forgot how to fly.  _USER paid the price.",
+		"_USERBY forgot how to fly. _USER found that out the hard way.",
+		"RIP _USER.  There's no funeral service since _USERBY is still paying their _VEHICLE Insurance Premium.",
+		"Really, _USER?  Next time you're in _USERBY's _VEHICLE, familiarise yourself with the eject feature.  If you get in their _VEHICLE again, that is.",
+		"ATTENTION!  _USERBY just obliterated _USER!\nHow you ask?  _USERBY had one too many to drink and crashed their _VEHICLE.",
+		"_USERBY hit a stray branch with their _VEHICLE and rooted _USER's death!",
+		"_USERBY hit a stray branch with their _VEHICLE and killed _USER in a fiery inferno!",
+		"Who let _USERBY drink?  They did 3 loop-de-loops, flew upside down, went sideways and crashed backwards into a resupply tower.  Don't believe me?  Ask _USER!  Perhaps wait until they finish using the bucket, though.",
+		"After much deliberation, NC headquarters has deemed it appropriate to revoke _USERBY's _VEHICLE flying privilages.\n_USER, you will be sent a bonus check in due time for this incident.\n\nPlease alert us if _USERBY is seen flying a _VEHICLE again!",
+		"_USER got too comfortable in _USERBYs _VEHICLE...  \n\nCan I have some of those marshmellows?",
+		"_USER just became part of the scenery.  You can find their 'additions' right next to the burning remains of _USERBY's _VEHICLE.",
+		"Attention, _USERBY.\nYou have been enrolled on a _VEHICLE Flight training course, courtesy of _USER",
+	]
+	############
+	"""# Flight Death by:
+	When a user(s) (`_USER`) is killed by being in someone elses(`_USERBY`) galaxy/Valk (`_VEHICLE`)"""
+
+
+
+	morningGreetings = [
+		"G'Mornin', _USER!",
+		"Morning! :D",
+		"It is?",
+		"Is it?",
+		"Top o' the mornin' to ya, _USER!",
+		"Afternoon. :)",
+		"Hello there _USER!",
+		"_USER, it's too early.  Go back to bed.",
+		"And a glorious morning to you, too, _USER!",
+		"Why are you awake? Why are you awake?!",
+		"I've checked with my bar clock, and I have to disagree with you, Sir.",
+		"I've checked with my bar clock, and I must say you're positively delirious, Sir.",
+		"... You've had one too many drinks today, _USER",
+		"Are you sure?",
+		"I'm going back to bed...",
+		"Glorious pleasantries to you too, _USER!",
+		"It's 5 o'Clock somewhere. 🍷",
+		"Morning, _USER. \nI heard you flown with Cactus recently... how was it?  Did he _FLIGHTDEATHREASON?",
+		"Morning, _USER. \nI heard you flown with DoubleD recently... how was it?  Did he _FLIGHTDEATHREASON?",
+		"¿ɹǝpun uʍop ǝɟıl s,ʍoɥ  ¡ƃuıuɹoɯ pooƃ",
+	]
+
+
+	morningGreetingsGif = [
+		"https://giphy.com/gifs/hello-hi-wave-xT9IgG50Fb7Mi0prBC",
+		"https://giphy.com/gifs/halloween-morning-grumpy-4rKr0feK7xfO0",
+		"https://tenor.com/bAFsa.gif",
+		"https://tenor.com/rvIY.gif",
+		"https://tenor.com/blv8V.gif",
+		"https://media.tenor.com/PZf33FwKn-0AAAAd/good-morning-funny.gif",
+		"https://giphy.com/gifs/warnerarchive-warner-archive-julie-christie-petulia-26uf05j0KemLdP58A",
+		"https://media3.giphy.com/media/j6BdaJIYXPSkUOF33H/giphy.gif",
+		"https://media.tenor.com/vL8iJNn7tjcAAAAM/awake-woke.gif",
+		"https://media.tenor.com/Pb2FdndScvgAAAAd/good-morning-unhappy.gif",
+		"https://media.tenor.com/lzNPKl40wigAAAAM/figaro-pinocchio.gif",
+		"https://media.tenor.com/bT5Ha1rqXpkAAAAM/no-u-michael-scott-no-u.gif",
+		"http://giphygifs.s3.amazonaws.com/media/ANbD1CCdA3iI8/200.gif",
+	]
+
+
+	# Specific to morning greeting.
+	flightDeathReason = [
+		"prematurely explode",
+		"crash into a stray tree and die in a fiery inferno",
+		"forget which way is up",
+		"have one too many to drink",
+		"manage to not crash it this time"
+	]

--- a/src/botData/envVars.py
+++ b/src/botData/envVars.py
@@ -1,0 +1,8 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+DISCORD_TOKEN = os.getenv('DISCORD_TOKEN')
+DISCORD_GUILD = os.getenv('DISCORD_GUILD')
+PS2_SVS_ID = os.getenv('PS2_SVS_ID')
+BOT_DIR = os.getcwd()

--- a/src/botData/sanityChecker.py
+++ b/src/botData/sanityChecker.py
@@ -1,0 +1,279 @@
+"""
+SANITY CHECKER
+
+Class, functions and exceptions for checking sanity of settings.
+If critical settings are invalid, prevents the bot from running.
+"""
+from __future__ import annotations
+
+from discord import Role, SelectOption
+from discord.ext.commands import Bot
+from botData.settings import BotSettings, NewUsers, Commander, UserLib, Roles, Channels
+from botUtils import BotPrinter as BUPrint
+
+class BadChannelError(Exception):
+	"""
+	# EXCEPTION: BAD CHANNEL:
+	Raised when required channels are not set.
+	"""
+	def __init__(self):
+		super().__init__("An invalid channel name or ID was set.  See above for more details.")
+
+
+class BadGuildError(Exception):
+	"""
+	# EXCEPTION: BAD GUILD
+	Raised when the guild is invalid.
+	"""
+	def __init__(self):
+		super().__init__(f"Guild not found with ID {BotSettings.discordGuild}. Check Guild ID is correct and bot is present in the guild.")
+
+
+class BadRoleError(Exception):
+	"""
+	# EXCEPTION: BAD ROLE:
+	Raised when required roles are not set/invalid.
+	"""
+	def __init__(self):
+		super().__init__("An invalid role name or ID was set.  See above for more details.")
+
+
+
+class SanityCheck():
+	"""
+	# SANITY CHECK
+	Class with functions to check sanity of setting values.
+	If botSettings.bEnableDebug` is true, this only prints warnings.
+	"""
+
+	async def CheckAll(p_botRef:Bot):
+		"""
+		# CHECK ALL
+		Runs all check functions.
+		"""
+		if BotSettings.bDebugEnabled:
+			BUPrint.Info("\n\nATTENTION: Debug is enabled.  Sanity check will only inform of invalid values\n\n")
+		else:
+			BUPrint.Info("Performing settings sanity check...")
+
+		await SanityCheck.CheckGuild(p_botRef)
+		await SanityCheck.CheckRoles(p_botRef)
+		await SanityCheck.CheckChannels(p_botRef)
+
+		if not BotSettings.bDebugEnabled:
+			BUPrint.Info("	-> Settings Sanity Check Passed!")
+
+
+
+	async def CheckGuild(p_botRef:Bot):
+		BUPrint.Info("Sanity Checking Guild...")
+
+		vGuild = p_botRef.get_guild(BotSettings.discordGuild)
+		if vGuild == None:
+			BUPrint.LogError(f"{BotSettings.discordGuild}", "INVALID GUILD ID:")
+
+			await p_botRef.close()
+			raise BadGuildError()
+
+
+	async def CheckRoles(p_botRef:Bot):
+		"""
+		# CHECK ROLES:
+		Checks if any required roles are invalid.
+		"""
+		BUPrint.Info("Sanity Checking Roles...")
+
+		guild = p_botRef.get_guild(BotSettings.discordGuild)
+		allRoles = guild.roles
+		botFeatures = BotSettings.botFeatures
+		bFailedCheck = False
+
+		if len(Roles.roleRestrict_ADMIN):
+			for adminID in Roles.roleRestrict_ADMIN:
+				adminUser = p_botRef.get_user(adminID)
+				if adminUser == None:
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  ADMINISTRATOR", p_string=str(adminID))
+					bFailedCheck = True
+
+		# BOT SETTINGS: Role restrict values
+		for roleStr in Roles.roleRestrict_level_0:
+			if not SanityCheck.RoleInRoles(roleStr, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Restriction Level 0", p_string=roleStr)
+				bFailedCheck = True
+		
+		for roleStr in Roles.roleRestrict_level_1:
+			if not SanityCheck.RoleInRoles(roleStr, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Restriction Level 1", p_string=roleStr)
+				bFailedCheck = True
+		
+		for roleStr in Roles.roleRestrict_level_2:
+			if not SanityCheck.RoleInRoles(roleStr, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Restriction Level 2", p_string=roleStr)
+				bFailedCheck = True
+		
+		for roleStr in Roles.roleRestrict_level_3:
+			if not SanityCheck.RoleInRoles(roleStr, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Restriction Level 3", p_string=roleStr)
+				bFailedCheck = True
+
+		if botFeatures.NewUser or botFeatures.UserLibrary:
+			# AUTO ASSIGN ROLES
+			for autoRoleID in Roles.autoAssignOnAccept:
+				if not SanityCheck.RoleInRoles(autoRoleID, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  NewUsers: AutoAssign", p_string=str(autoRoleID))
+					bFailedCheck = True
+
+			# RECRUIT ROLE
+			if not SanityCheck.RoleInRoles(Roles.recruit, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  NewUsers: Recruit", p_string=str(Roles.recruit))
+				bFailedCheck = True
+
+		if botFeatures.NewUser:
+			for selectOpt in Roles.newUser_roles:
+				if not SanityCheck.RoleInRoles(selectOpt.value, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  New User Role Select Option", p_string=str(selectOpt.value))
+					bFailedCheck = True
+
+
+		if botFeatures.UserLibrary:
+			# PROMOTION ROLE
+			if not SanityCheck.RoleInRoles(Roles.recruitPromotion, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  UserLib: Promotion", p_string=str(Roles.recruitPromotion))
+				bFailedCheck = True
+
+			# SLEEPER ROLE
+			if not SanityCheck.RoleInRoles(Roles.sleeperRoleID, allRoles):
+				BUPrint.LogError(p_titleStr="INVALID ROLE |  UserLib: Sleeper", p_string=str(Roles.recruitPromotion))
+				bFailedCheck = True
+
+		if botFeatures.UserRoles:
+			# TDKD ROLES
+			for selectOpt in Roles.addRoles_TDKD:
+				if not SanityCheck.RoleInRoles(selectOpt.value, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Selector: TDKD", p_string=selectOpt.value)
+					bFailedCheck = True
+
+			for selectOpt in Roles.addRoles_games1:
+				if not SanityCheck.RoleInRoles(selectOpt.value, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Selector: Games 1", p_string=selectOpt.value)
+					bFailedCheck = True
+
+			for selectOpt in Roles.addRoles_games2:
+				if not SanityCheck.RoleInRoles(selectOpt.value, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Selector: Games 2", p_string=selectOpt.value)
+					bFailedCheck = True
+
+			for selectOpt in Roles.addRoles_games3:
+				if not SanityCheck.RoleInRoles(selectOpt.value, allRoles):
+					BUPrint.LogError(p_titleStr="INVALID ROLE |  Role Selector: Games 3", p_string=selectOpt.value)
+					bFailedCheck = True 
+
+		if bFailedCheck:
+			if BotSettings.bDebugEnabled:
+				BUPrint.LogError(p_titleStr="ROLES FAILED CHECK", p_string="One or more roles has an invalid value.\n\n")
+			else:
+				await p_botRef.close()
+				raise BadRoleError()
+
+
+
+	def RoleInRoles(p_roleNameOrID:str, p_RolesList:list[Role]):
+		"""
+		Checks if role is in list of roles.
+
+		roleName or ID can be provided.
+
+		Returns TRUE if found. False if not.
+		"""
+		for role in p_RolesList:
+			if role.name == p_roleNameOrID:
+				return True
+
+			try:
+				if p_roleNameOrID.isnumeric():
+					if role.id == p_roleNameOrID:
+						return True
+			except AttributeError:
+				if role.id == p_roleNameOrID:
+					return True
+
+
+		return False
+
+
+	async def CheckChannels(p_botRef:Bot):
+		""" # CHECK CHANNELS:
+		Checks if required channels are present.
+		"""
+		BUPrint.Info("Sanity Checking Channels...")
+
+		botFeatures = BotSettings.botFeatures
+		checkChannel = None
+		vGuild = p_botRef.get_guild(BotSettings.discordGuild)
+		if vGuild == None:
+			await p_botRef.close()
+			raise BadGuildError()
+		bFailedCheck = False
+
+		if botFeatures.NewUser or botFeatures.UserLibrary:
+			# ADMIN CHANNEL
+			checkChannel = vGuild.get_channel( Channels.botAdminID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Admin Channel")
+				bFailedCheck = True
+
+			# GENERAL CHANNEL
+			checkChannel = vGuild.get_channel( Channels.generalID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="General Text")
+				bFailedCheck = True
+
+		if botFeatures.Operations:
+			# SCHEDULE CHANNEL
+			checkChannel = vGuild.get_channel( Channels.scheduleID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Schedule")
+				bFailedCheck = True
+
+
+			# FALLBACK VOICE CHAT
+			checkChannel = vGuild.get_channel( Channels.voiceFallback )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Voice Fallback")
+				bFailedCheck = True
+
+			# COMMANDER MOVEBACK CHANNEL
+			if Commander.bAutoMoveVCEnabled:
+				checkChannel = vGuild.get_channel( Channels.eventMovebackID )
+				if checkChannel == None:
+					BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Event AutoMoveback")
+					bFailedCheck = True
+
+			# SOBER FEEDBACK
+			checkChannel = vGuild.get_channel( Channels.soberFeedbackID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Sober Feedback")
+				bFailedCheck = True
+
+
+		if botFeatures.NewUser:
+			# GATE CHANNEL
+			checkChannel = vGuild.get_channel( Channels.gateID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Gate")
+				bFailedCheck = True
+
+
+		if botFeatures.ForFunCog:
+			checkChannel = vGuild.get_channel( Channels.ps2TextID )
+			if checkChannel == None:
+				BUPrint.LogError(p_titleStr="INVALID CHANNEL ID | ", p_string="Planetside 2 Text")
+				bFailedCheck = True
+
+
+		if bFailedCheck:
+			if BotSettings.bDebugEnabled:
+				BUPrint.LogError(p_titleStr="CHANNELS FAILED CHECK", p_string="One or more channels has an invalid value.\n\n")
+			else:
+				await p_botRef.close()
+				raise BadChannelError

--- a/src/botData/settings.py
+++ b/src/botData/settings.py
@@ -1,0 +1,957 @@
+"""
+SETTINGS
+
+All settings for the bot are listed below, split into classes which can act as headers for easier finding.
+These settings pertain to the overall behaviour of the bot, not individual items.
+
+If you're looking for Emoji Library, see `botData.utilityData.EmojiLibrary`.
+
+For more help:
+https://github.com/LCWilliams/planetside-discord-bot/wiki/Bot-Configuration/
+"""
+from __future__ import annotations
+
+from discord import SelectOption
+import botData.dataObjects
+from dateutil.relativedelta import relativedelta
+from datetime import time, timezone
+import botData.envVars as Env
+from dataclasses import dataclass
+from enum import Enum
+from sys import stderr
+import pickle
+
+
+
+@dataclass(frozen=True)
+class BotSettings:
+	# TOKENS LOADED FROM .ENV FILE
+	discordToken = Env.DISCORD_TOKEN
+	discordGuild = int(Env.DISCORD_GUILD)
+	ps2ServiceID = Env.PS2_SVS_ID
+	botDir = Env.BOT_DIR
+
+
+	botFeatures = botData.dataObjects.BotFeatures(
+		# Bot Admin: Enables commands specifically for administrative bot tasks (currently, just show config & shutdown)
+		BotAdmin= True,
+
+		# New User: Enables a feature that monitors for new users, who are presented with a dialog to enter their PS2 name, read the rules and request access.
+		# On requesting access, a request is sent to the bot-admin channel for an admin to review & assign role, or kick/ban the user.  
+		NewUser= True,
+
+		# User Library: Cog which saves specific data about users to file, including their PS2 name, birthdate (if provided), a mini about, any saved sessions, and admin messages.
+		# There is an administative cog associated with the user library, containing administrative commands.
+		UserLibrary= True,
+
+		# User Library: Inbox System - Allows sending discreet messages to the user via their own inbox.  A discord-safe alternative since some users may have direct messages disabled.
+		userLibraryInboxSystem= True,
+
+		# User Library: Inbox system - Admin: Allows admins to send warnings to users, either about a message, or generally; via right clicking (a message, or the user)
+		userLibraryInboxAdmin= True,
+
+		# Fun features of UserLibrary cog.  Fun Features are non-serious and generally just for humour.
+		UserLibraryFun = True,
+
+		# Operations:  Cog which contains commands to create, edit and delete operations (live and defaults), and operation commanders.
+		Operations= True,
+
+		# Chat Utility: Cog with administrative commands for chats & category manipulation, and linking voice-chat to text-chat channels.
+		chatUtility= True,
+
+		# User Roles: Cog which enables users to self-assign roles using a command (or button on newUser, if enabled)
+		UserRoles= True,
+
+		# For Fun Cog: Cog that implements 'for fun' features that do not depend on other bot functionality.
+		ForFunCog=True,
+	)
+	"""# BOT FEATURES:  Convenience setting to Enable or Disable Cog functionality.  Any co-dependnacy will behave based on these settings.
+	"""
+
+	bDebugEnabled = True
+	"""# Debug Enabled: set to false during live use to reduce console clutter.
+	"""
+
+	bShowSettingsOnStartup = True
+	"""# Show Settings on Startup: When true, the bots settings are displayed in the console.
+	"""
+
+	bShowSettingsOnStartup_discord = False
+	"""# Show settings on startup: Discord: Same as above, but posts the config into bot-admin channel
+	"""
+
+	bForceRoleRestrictions = True
+	"""Force Role restrictions: 
+	when true, hard-coded restrictions prohibit command usage based on the roles in roleRestrict variables.
+	users unable to call commands setup within the discord client are still unable to call commands regardless of this setting.
+	As such, this is merely a redundancy if security concerned.
+	
+	Check Roles below to see the individual levels."""
+
+	errorOutput = stderr
+	"""# Error Output: Where error output is sent; if not stderr, must be a file path.
+	"""
+
+	bCheckValues = True
+	"""# CHECK VALUES: 
+	When true, values are sanity checked on bot start, recommended to stay on.
+	If Debug is enabled, this prints out any invalid entries, else it prevents bot from continuing."""
+
+
+	pickleProtocol = pickle.HIGHEST_PROTOCOL
+	"""# Pickle Protocol: 
+	Int value denoting the pickle protocol to use."""
+
+
+	bBotAdminCanPurge = False
+	"""# Bot Admin Can Purge:
+	When true, the bot admin channel can be purged on startup/shutdown.
+	Helpful to keep the channel clear of non-functional views after a bot restart."""
+
+
+	
+
+@dataclass(frozen=True)
+class Roles:
+	"""
+	# ROLES
+	Individual roles used by the bot.
+
+	For convenience, all roles used within selectors are also stored here
+
+	NOTE: Selectors have a MAXIMUM limit of 25 items;
+			This is a discord imposed limit.
+	"""
+	# ROLE RESTRICTION LEVELS:
+	roleRestrict_level_0 = ["CO"]
+
+	roleRestrict_level_1 = ["Captain", "Lieutenant"]
+
+	roleRestrict_level_2 = ["Sergeant", "Corporal", "Lance-Corporal"]
+
+	roleRestrict_level_3 = ["DrunkenDogs", "Recruits", "The-Washed-Masses", "The-Unwashed-Masses"]
+	
+	roleRestrict_ADMIN = [182933627242283008] # LIVE VALUE: Cactus
+	"""	# ROLE RESTRICT: ADMIN
+	A special role restrict reserved specifically for those entrusted with BotAdmin. While named roleRestrict, only User IDs should be used."""
+	
+	
+	recruit = 780253442605842472
+	"""# Recruit
+	ID of the recruit role."""
+
+	
+	recruitPromotion = 710472193045299260 # DrunkenDog
+	"""# recruit Promotion
+	The ID of the role recruits are promoted to.
+	
+	NOTE: If sleeper feature is enabled; 
+	this is the role used to check if the user is part of the outfit."""
+
+
+	sleeperRoleID = 0
+	"""# Sleeper Role ID
+	ID of a role assigned to users who meet the sleeper requirements."""
+
+
+	autoAssignOnAccept = [
+		818218528372424744, # Tags
+		]
+	"""# Auto Assign on Accept:
+	List of role IDs that are always assigned to users when their join request is accepted."""
+
+
+	newUser_roles = [ 
+		SelectOption(label="Recruit", value=f"{recruit}"),
+		SelectOption(label="Drunken Dog", value="710472193045299260"),
+		SelectOption(label="The Washed Masses", value="710502581893595166"),
+		SelectOption(label="The Unwashed Masses", value="719219680434192405")
+	]
+	"""New User Roles:  Roles listed in a new user join request that an admin may assign."""
+
+
+	addRoles_TDKD = [
+		SelectOption(label="Planetside Pings", value="977873609815105596", description="Non-major PS2 events/fellow\n drunken doggos looking for company"),
+		SelectOption(label="Sober Dogs", value="745004244171620533", description="More serious, coordinated infantry events"),
+		SelectOption(label="Base Busters", value="811363100787736627", description="Base building and busting events"),
+		SelectOption(label="Armour Dogs", value="781309511532544001", description="Ground vehicle related events"),
+		SelectOption(label="Dog Fighters", value="788390750982766612", description="Small aerial vehicle related events"),
+		SelectOption(label="Royal Air Woofs", value="848612413943054376", description="Heavy aerial vehicle related events"),
+		SelectOption(label="PS2 Twitter", value="832241383326744586", description="Planetside 2 Twitter posts"),
+		SelectOption(label="Jaeger", value="1024713062776844318", description="Jeager events")
+	]
+	"""Add Roles: TDKD:  Roles listed in the "TDKD" selector for the /roles commands."""
+
+
+	addRoles_games1 = [
+		SelectOption(label="Apex Legends", value="825106272856571985"),
+		SelectOption(label="Back 4 Blood", value="916804112337756160"),
+		SelectOption(label="Battlefield 2042", value="894232796619472987"),
+		SelectOption(label="Conqueror's Blade", value="896008973906509885"),
+		SelectOption(label="Deep Rock Galactic", value="803340218756366423"),
+		SelectOption(label="Dungeon and Dragons", value="864175083152343070"),
+		SelectOption(label="Eve Online", value="900009823867916310"),
+		SelectOption(label="Factorio", value="939894580688605274"),
+		SelectOption(label="Garrys' Mod", value="916803968674439300"),
+		SelectOption(label="Gates of Hell", value="1000366778133774528"),
+		SelectOption(label="Killing Floor 2", value="916804287370240131"),
+		SelectOption(label="Minecraft", value="824708493076201473"),
+		SelectOption(label="Post Scriptum", value="791308463241691146"),
+		SelectOption(label="Sea of Thieves", value="916802105719783454"),
+		SelectOption(label="Stellaris", value="911972761948266547"),
+		SelectOption(label="Supreme Commander", value="887338095802982441"),
+		SelectOption(label="Space Engineers", value="805234496026050601"),
+		SelectOption(label="Squad", value="808413252685529108"),
+		SelectOption(label="Team Fortress 2", value="826943611303100496"),
+		SelectOption(label="Terraria", value="825106136378245180"),
+		SelectOption(label="Total War: Warhammer", value="931201327869079553"),
+		SelectOption(label="Valheim", value="818490876631711794"),
+		SelectOption(label="Vermintide", value="929376317944791040"),
+		SelectOption(label="Warframe", value="872593227734208512"),
+		SelectOption(label="Warthunder", value="976598559266857030"),
+	]
+	"""Add Roles: Games 1:  Roles listed in the "Games 1" selector for the /roles commands."""
+
+	addRoles_games2 = [
+		SelectOption(label="Overwatch", value="1029138196518420531"),
+		SelectOption(label="Star Citizen", value="1037797784566370318"),
+		SelectOption(label="World of Tanks", value="1038125253806788768"),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value="")
+	]
+	"""Add Roles: Games 2:  Roles listed in the "Games 2" selector for the /roles commands."""
+
+	addRoles_games3 = [
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value=""),
+		# SelectOption(label="", value="")
+	]
+	"""Add Roles: Games 3:  Roles listed in the "Games 3" selector for the /roles commands."""
+
+
+
+class CommandRestrictionLevels(Enum):
+	"""
+	# COMMAND RESTRICTION LEVELS
+	Convenience Enum for setting levels, or to get a list of roles.
+
+	Should almost always be used instead of raw roleRestrict_level_n
+
+	Use `botUtils.UserHasCommandPerms` to check if a calling user has valid permissions.
+
+	NOTE: Not to be edited: for changing values, edit `BotSettings.roleRestrict_level_x`
+	"""
+	level0 = Roles.roleRestrict_level_0
+	level1 = level0 + Roles.roleRestrict_level_1
+	level2 = level1 + Roles.roleRestrict_level_2
+	level3 = level2 + Roles.roleRestrict_level_3
+
+
+
+
+@dataclass(frozen=True)
+class CommandLimit:
+	"""
+	# COMMAND LIMIT
+	Settings pertaining to each command and certain button usage in the bot;
+	Stored here to avoid needing to hunt down individual files and commands.
+
+	NOTE: Admin cog has no CommandLimit entry, because it uses the direct roleRestrict_ADMIN value.
+	"""
+	validateNewuser = CommandRestrictionLevels.level1
+	"""Command limit for New User validation buttons."""
+
+	userRoles = CommandRestrictionLevels.level3
+	"""Command limit for User Roles commands"""
+
+	opManager = CommandRestrictionLevels.level1
+	"""Command limit for Op Manager commands."""
+
+	opCommander = CommandRestrictionLevels.level2
+	"""Command limit for Op Commander commands."""
+
+	userLibrary = CommandRestrictionLevels.level3
+	"""Command limit for User library commands, specific to general users"""
+
+	userLibraryAdmin = CommandRestrictionLevels.level1
+	"""Command limit for user library commands, specific to administrative commands."""
+
+	chatUtilities = CommandRestrictionLevels.level1
+	"""Command limit for chat utility commands."""
+
+
+
+@dataclass(frozen=True)
+class Channels:
+	"""
+	# CHANNELS
+	Channel name/IDs used by the bot. 
+	
+	Since multiple features may use these, they're stored here to avoid duplicates and messy name inclusions.
+	"""
+
+	botAdminID = 0
+	"""# Bot Admin: 
+	The channel administrative tasks and notifications are sent to."""
+
+	
+	gateID = 0
+	"""# Gate Channel: 
+	The channel considered to be the servers gate: should be viewable to new users.  It does not require chatting privilages."""
+
+
+	ruleID = 913086821263626360
+	"""# Rule Channel: 
+	ID of the rule channel used to fetch the rules Message. """
+
+
+	generalID = 710469797439078400 # (general)
+	"""	# General Chat: 
+	ID of the general text channel."""
+
+	
+	voiceFallback = 710854499782361140 # (general)
+	"""# Voice Fallback: 
+	A channel that users are moved to when their current one is removed (by the bot)"""
+
+	
+	eventMovebackID = 1023703124839518338 # (planetside2)
+	"""# Event MoveBack: 
+	ID of voice chat users are moved into after an event is over."""
+
+	
+	protectedCategoriesID = [
+		744907524418961438, # Welcome
+		710470871214587955, # Important Channels
+		818212652601966628, # Sign-up
+		710471344411770881, # The Drunken Dogs
+		734791662798241854, # Games
+		1026549992829222952, # Jaeger
+		710470038968205393, # Planetside
+		1042450013827117087, # Soberdogs Stuff
+		796885440916488252, # Guides
+		]
+	"""# Protected Categories: 
+	ID of categories that cannot be deleted by chatMonitor.remove_category"""
+
+
+	quoteID = 1036349723059159040
+	"""# Quote Channel ID: 
+	If this is not found, the event listener is not added."""
+
+	
+	soberFeedbackID = 1042463290472800317
+	"""# Sober Feedback: 
+	ID of the soberDogs feedback/debrief FORUM."""
+
+
+	ps2TextID = 715337156255809568
+	"""# PS" Text ID:
+	ID of the planetside 2 TEXT channel."""
+
+
+	scheduleID = 818186731202936843
+	"""# Schedule ID:
+	ID of the schedule text channel"""
+
+
+
+@dataclass(frozen=True)
+class NewUsers:
+	"""
+	# NEW USERS
+	Settings pertaining to the bot behaviour for `NewUser` cog.
+	"""
+
+	bPurgeGate = False
+	"""# Purge Gate:
+	When true, the gate channel is purged on shutdown/startup"""
+
+	bCreateLibEntryOnAccept = True
+	"""	# Create Library Entry on Accept: 
+	When true, after a user has been accepted, automatically create a user entry for them."""
+
+	
+	bLockPS2CharOnAccept = True
+	"""# Lock PS2 Character on Accept:
+	When true (and user library enabled), disable allowing a user to change their character name via viewer config."""
+
+	
+	outfitRankWarn = 4
+	"""# Outfit Rank Warning
+	Warn if a joining user claims a ps2 character name with a rank equal or higher than this (numerical, lower = higher rank.)"""
+
+
+	newAccntWarn = 3
+	"""# New Account Warning:
+	Warn when a joining users account is less than this many months old."""
+
+	
+	ruleMsgID = 977888774530932767
+	"""# Rule Message ID:
+	The id of a message which contains the server rules (if not in an embed, falls back to message content)  Make sure `Channels.ruleID` is also set."""
+
+
+	bShowAddRolesBtn = True
+	"""# Show Add Roles Button:
+	When true, a button to add roles is shown in the welcome message.
+	It is advisable to ensure the message "NewUserWelcome" reflects the presence (or lack thereof) of this button."""
+
+
+
+
+
+@dataclass(frozen=True)
+class Commander:
+	"""
+	# COMMANDER
+	Settings used by Op Commanders.
+	"""
+	
+	bTrackingIsEnabled = True
+	"""# Tracking is Enabled: 
+	When true, the PS2 tracker is used for PS2 events."""
+
+	
+	markedPresent = botData.dataObjects.PS2EventAttended.InGameOnly
+	"""# Marked Present: 
+	Setting to determine when a participant is considered part of the event and their userLib entry is updated.
+	A present participant has their "attended" value updated and the session stats saved."""
+
+	
+	bSaveNonPS2ToSessions = True
+	"""# Save Non PS2 Events to Sessions: 
+	When true, an entry for non-PS2 events is added to a users session history.
+	Because there's no stats to show, only the date, duration and a message informing it isn't for ps2 are shown."""
+
+
+	
+	gracePeriod = 10 # Minutes
+	"""# Grace Period: 
+	The time after an ops has started before participants are evaluated and marked non attending if they fail the requirements for markedPresent."""
+
+	
+	bAutoStartEnabled = True
+	"""# Auto Start Commander:
+	When true, Ops Commanders will automatically *start* their operation at the defined start time."""
+
+	
+	bAutoAlertsEnabled = True
+	"""# Enable Commander Auto Alerts: 
+	If true, Op Commanders will periodically alert users a set amount of times (below)"""
+
+
+	autoAlertCount = 3
+	"""	# Commander Auto Alert Count: 
+	The number of automatic alerts a commander will send. These are distributed throughout the pre-start time."""
+
+	
+	bAutoMoveVCEnabled = True
+	"""# Commander- Auto Move Voice Channel: 
+	If enabled, participating users are moved to the standby channel on Ops start if they're in a voice channel."""
+
+	
+	autoPrestart = 45
+	"""# Auto Prestart:
+	Number of minutes before an ops scheduled start the bot prestarts AutoStart enabled Ops (Non AutoStart enabled Ops require a user to use `/ops-commander` command)
+	NOTE: A buffer of 5 minutes is added to this time to ensure sufficient time for setup (especially in the case of a slow connection/bot)."""
+
+
+	dataPointInterval = 60
+	"""	# Data Point Interval:
+	Interval in seconds a new data point for event tracking is set."""
+
+
+	defaultChannels = botData.dataObjects.DefaultChannels(
+		# Text Channels: Persistent text channels that are always created.
+		textChannels= [],
+
+		# The Name of the channel the COMMANDER is in.
+		opCommander = "Commander",
+
+		# Notifications: Name of the channel notifications & feedback messages are sent to.
+		notifChannel = "Notifications",
+
+		# Standby Voice Channel: Name of channel users are automatically moved into (if enabled) when ops starts.
+		standByChannel= "Standby",
+
+		# Persistent Voice: Same as Text Channels- always created voice channels.
+		persistentVoice= [],
+		
+		# Voice Channels: If custom channels are not specified in the Op Data, these are used instead.
+		voiceChannels= ["Squad-Alpha", "Squad-Bravo", "Squad-Charlie", "Squad-Delta"]
+	)
+	"""# DEFAULT CHANNELS:
+	Voice and text channels used by all events."""
+
+
+	# Icons for the CONNECTIONS embed.
+		# Discord
+	connIcon_discord = "🖥️"
+	connIcon_discordOnline = "🟢"
+	connIcon_discordOffline = "🔴"
+		# Discord Voice
+	connIcon_voice = "🎧" 
+	connIcon_voiceConnected = "🟢"
+	connIcon_voiceNotEventChan = "🟡"
+	connIcon_voiceDisconnected = "🔴"
+		# Planetside2
+	connIcon_ps2 = "🎮"
+	connIcon_ps2Online = "🟢"
+	connIcon_ps2Offline = "🔴"
+	connIcon_ps2Invalid = "❌" # Users who have an invalid/non-matching PS2 name
+	connIcon_ps2Recruit = "🚼" # Shown when user is a recruit (requires User Library)
+	
+
+
+
+
+@dataclass(frozen=True)
+class SignUps:
+	"""
+	# SIGNUPS
+
+	Settings used by signups.
+
+	NOTE:  These are NOT settings for individual signups! See `botData.operations.operationOptions` for those.
+	"""
+
+	bAutoParseSchedule = True
+	"""# Auto Parse Schedule
+	When true, messages in the specified SCHEDULE channel are parsed.
+	If any matching events are found, the bot will offer to make them."""
+
+	autoParseTimeout = 300
+	"""# Auto Parse Timeout:
+	The number of seconds before the view and message for an auto-parse message is removed."""
+
+	
+	bAutoRemoveOutdated = True
+	"""# Auto Remove Outdated: 
+	On startup, or any call to Refresh Ops; if the event date is before the current date, remove it. """
+	
+	
+	signupCategory = "SIGN UP"
+	"""# Signup Category
+	The category name (results are searched in lower, so this is generally case insensitive.)
+	If not found, this category is created."""
+
+	
+	bResignAsButton = True
+	"""# Resign as Button:
+	True, Resign is a separate button. False, Resign is added to the role selector."""
+
+	
+	resignIcon = "❌"
+	"""# Icon used for built in RESIGN role."""
+
+	
+	reserveIcon = "⭕"
+	"""# Icon used for built in RESERVE role"""
+
+	
+	bAutoPrestartEnabled = True
+	"""# Auto Prestart Enabled: 
+	If true, an Ops commander is created automatically at the auto-prestart adjusted time.
+	This is a global overwrite. Individual ops have an option to disable this."""
+
+	
+	bShowOptsInFooter = True
+	"""# Show Options in Footer: 
+	When true, the ops settings are shown in the footer, in a condensed format;
+	"AS:E|UR:E|UC:D|SDF:D" - AutoStart: Enabled, Use Reserve: Enabled, Use Compact: Disabled, Soberdogs Feedback: Disabled """
+
+	
+	maxRoles = 20
+	"""# Max Roles:
+	The maximum number of roles a single event can have.  
+	Must take into consideration discords limit of 25 embed elements, and 25 max select items."""
+
+
+
+
+@dataclass(frozen=True)
+class UserLib:
+	"""
+	# USER LIBRARY
+	Settings pertaining to the behaviour of the user library.
+	"""
+	
+	entryRetention = botData.dataObjects.EntryRetention.alwaysLoaded
+	"""# Entry Retention: 
+	How user library entries are kept in memory: Always loaded, UnloadAfter, and WhenNeeded.
+	NOTE: Unload after hasn't been properly tested."""
+
+	
+	entryRetention_unloadAfter = 30 # minutes.
+	"""#Entry Retention: Unload after- 
+	If `UnloadAfter` is used, entries are removed if they haven't been "got" or "saved" within this period. """
+
+	
+	entryRetention_checkInterval = 5 # Minutes
+	"""# Entry Retention: Check Interval: 
+	The interval the checking task is set to.  If `unloadAfter` is not set, this task is not added."""
+
+
+	bEnableSpecialUsers = True
+	"""# Enable Special Users: 
+	when true, user viewer checks for a matching ID .txt file.
+	The contents of this file are added to the General page; only admins are able to modify this text."""
+
+	
+	bEnableInbox = True
+	"""# Enable Inbox: 
+	When true, certain bot features may send an item to a users inbox (including admin warns)"""
+
+	
+	bCommanderCanAutoCreate = True
+	"""# Commander can Auto Create: 
+	When true, new user library entries are created for non-existant entries if a valid ps2 name is found from their username during a live operation."""
+
+	
+	bUserCanSelfCreate = True
+	"""# User Can Self Create: 
+	When true, if an entry doesn't exist for a user and its themself, a new entry is created."""
+
+	
+	maxSavedEvents = -1
+	"""# Max Saved Events:
+	The maximum number of saved events a users entry can hold.  -1 for no limit, or 0 to disable."""
+
+	
+	autoQueryRecruitTime = [
+		time(hour=10, minute=00, tzinfo=timezone.utc)
+	]
+	"""# Auto Query Recruit Time: 
+	The time(s) during the day in which all recruits are queried.
+	Querying a recruit checks the recruit requirements, if met; they are promoted/promotion validation request is sent."""
+
+	
+	bAutoPromoteEnabled = False
+	"""# Auto Promote Enabled: 
+	When true, after a user has met the requirements, they are promoted (if appropriate role found).
+	If False, a validation request is sent to the admin channel instead."""
+
+	
+	bEnforcePS2Rename = True
+	"""# Enforce PS2 Rename
+	When true, and a user provides a valid PS2 character name in the library viewer setup,
+	they are renamed to the newly provided name & outfit (if present)."""
+
+	
+	autoPromoteRules = botData.dataObjects.AutoPromoteRule(
+		# Attended Minimum Events: When true, a recruit must participate in the specified number of events.
+		bAttendedMinimumEvents = True,
+		# Whether Events MUST be PS2 to be considerd.
+		bEventsMustBePS2= True,
+		# The number of events a recruit must participate in.
+		minimumEvents = 4,
+		
+		# In Outfit For Duration: When true, a recruit must be in the ps2 outfit for the specified duration.
+		bInOutfitForDuration = True,
+		outfitDuration = relativedelta(days=7),
+
+		# In Discord For Duration: When true, a recruit must be in the discord server for the specified duration.
+		bInDiscordForDuration = True,
+		discordDuration = relativedelta(days=7)
+	)
+	"""# Auto Promote Rules: 
+	A dataclass containing rules/conditions for auto promotion."""
+	
+	sleeperRules = botData.dataObjects.SleeperRules(
+		bIsEnabled= True,
+		bSelfOutfitOnly=True,
+
+		bInbRecentEvent=True,
+		mostRecentEvent=relativedelta(months=3)
+	)
+	"""# SLEEPER RULES
+	A set of rules to determine when to apply the sleeper role to members.
+	"""
+	
+	sleeperCheckTime = time(hour=4, minute=0, tzinfo=timezone.utc)
+	"""# Sleeper Check Time:
+	The time of the day all users are queried for being asleep(inactive)."""
+
+	
+	sessionPreviewMax = 5
+	"""# Session Preview Max:
+	The number of saved sessions that are previewed in a libraryViewer general page."""
+
+	
+	sessionMaxPerPage = 10
+	"""# Session Browser Max Per Page:
+	Maximum number of sessions the browser page (and the dropdown) will show.  Cannot go above 25."""
+
+	
+	bRemoveEntryOnLeave = False
+	"""# Remove Entry On Leave:
+	If true, a users entry is removed when they leave the server."""
+
+	
+	bRemoveSpecialEntryOnLeave = False
+	"""# Remove Special Entry on Leave: 
+	If true, a users special entry is removed when they leave the server.
+	If enabled, requires `bRemoveEntryOnLeave` to also be TRUE."""
+
+	
+	bShowJumpButtonsForGetEvents = True
+	"""# Show Jump Buttons for Get Events: 
+	When true, when a user uses "/my_events", the result message includes a view with jump buttons to signupable events."""
+
+
+	# FUN STUFF: Settings here pertain to little funny things: due to their nonserious nature, they're not displayed in /Config or Console output.
+
+	topQuoteReactions = 5
+	"""# Top Quote: 
+	When a quote receives this amount of reactions, the mentioned user has the quote added to their library entry. 0 or negative value to disable."""
+
+	maxQuotes = 3
+	"""# Max Quotes:
+	The maximum number of saved/displayed top quotes a user can have in their entry."""
+
+
+
+
+dataclass(frozen=True)
+class ForFun:
+	"""# FOR FUN
+	Settings pertaining to non-serious features that are there "for fun".
+	"""
+	
+# MORNING GREETING SETTINGS
+	bMorningGreeting = True
+	"""# Morning Greeting: 
+	When true, the bot responds to a message containing "morning". (to avoid every instance, the message must have less than 3 space characters.)"""
+
+	bOnlyInGeneral = False
+	"""# Only in General: 
+	When true, if the channel isn't the specified general channel, don't respond."""
+
+	bMorningGreetingRandomGif = True
+	"""# Random Gif: 
+	When true, the bots selection of responses includes a list of gifs.  This is implied false if the gif list is empty."""
+
+	morningGreetingMinTime = relativedelta(minutes=5)
+	"""# Morning Greeting minimum time: 
+	the minimum time since the last greeting was sent, used to prevent spam."""
+
+	morningGreetings = botData.dataObjects.ForFunData.morningGreetings
+	"""# Morning Greetings: 
+	list of greetings to a user who says "morning", any instance of "_USER" is replaced with a mention.
+	Proxy to `DataObjects.ForFunData`"""
+
+	morningGreetingsGif = botData.dataObjects.ForFunData.morningGreetingsGif
+	"""# Morning Greetings GIF: 
+	list of gif greetings to a user who says "morning",.
+	Proxy to `DataObjects.ForFunData`"""	
+
+	flightDeathReason = botData.dataObjects.ForFunData.flightDeathReason
+	"""# Flight Death Reason: 
+	List of fun flight death reasons for a specific subset of text greetings.
+	Proxy to `DataObjects.ForFunData`"""
+
+# PS2 VEHICLE DEATHS:
+	bBroadcastPS2VehicleDeath = True
+	"""# PlanetSide2 Vehicle Death: 
+	When true, if a player is killed by another participants sunderer or galaxy, it's broadcasted to the PS2 text channel.
+	This only occurs during tracked events."""
+
+	bPS2VehicleDeathFunEvent = True
+	"""# Planetside 2 Vehicle Death: 
+	Fun event- when true, same as above except its added to users' UserLibrary.
+	This only occurs during tracked events."""
+
+
+
+
+@dataclass(frozen=True)
+class Directories:
+	"""
+	# DIRECTORIES
+
+	Directories used by the bot.
+
+	If changing the values, make sure slashes are present when needed.
+	"""
+
+	prefixDir = f"{BotSettings.botDir}/SavedData/"
+	"""Prefix Directory:
+	File directory to preceed all directories.  This is not hard-coded, if you so wish, each directory can be anywhere."""
+
+	liveOpsDir = f"{prefixDir}LiveOps/"
+	"""# Live Ops Dir:
+	Directory of saved data for LIVE events"""
+
+	savedDefaultsDir = f"{prefixDir}Defaults/"
+	"""# Saved Defaults:
+	Directory of saved data for DEFAULT events."""
+
+	userLibrary = f"{prefixDir}Users/"
+	"""# User Library:
+	Directory of saved data for user library entries"""
+
+	userLibraryRecruits = f"{userLibrary}Recruits/"
+	"""# User Library Recruits:
+	Directory of saved data for recruit user library entries.  
+	Seperated to make finding recruit entries more efficient."""
+
+	tempDir = f"{prefixDir}temp/"
+	"""# Temp Directory:
+	Directory of a temporary folder which is periodically cleaned out."""
+
+	lockFileAffix = ".LOCK"
+	"""# Lock File Affix:
+	Name of the affix to use for lock files."""
+
+	feedbackPrefix = "FEEDBACK_"
+	"""#Feedback Prefix:
+	The prefix to prepend on feedback text files."""
+
+	lockFileRetry = 5
+	"""# Lock File Retry:
+	Number of tries a function attempts to get a lock on a file- prevents multiple accessing at once."""
+
+	cleanTempEvery = 120 #Hours.
+	"""# Clean Temp Every:
+	Number of hours between each temp file emptying, starting from when the bot was started."""
+
+	bCleanTempOnShutdown = False
+	"""# Clean Temp on Shutdown:
+	When true, the bots temp directory is cleaned on shutdown."""
+
+
+
+
+@dataclass(frozen=True)
+class Messages:
+	"""
+	# MESSAGES
+	Messages used throughout the bot, typically for end-users, stored here for convenient editing purposes.
+	"""
+	
+	# Displayed in the GATE channel on bot startup (after purging).
+	gateChannelDefaultMsg = "Welcome to TDKD.\nIf a join request has not been created for you, or you have already sent one and it's no longer here, please re-join the server. \nOur bot has been restarted."
+
+	# Displayed in the embed for new users in their gate message.
+	newUserInfo = "Use the buttons below to provide your Planetside 2 character name (if you have one) and accept the rules.\nThen you can request access, and wait for one of our admins to get you set up!"
+
+	# Displayed in the embed for new users in their gate message, under ACCEPTANCE OF RULES.
+	newUserRuleDeclaration = "By pressing 'ACCEPT', you are confirming **you have read**, **understand**, and **agree to adhere** by the rules."
+
+	# Confirmation message sent to users who have accepted the rules
+	newUserAcceptedRules = "Thank you for accepting the rules.  You may now request access!"
+
+	# Displayed when a new user is accepted.  Use _ROLE and _MENTION to have the assigned role and/or mention inserted.
+	newUserWelcome = f"""Welcome, _MENTION!
+	You have been assigned the role: _ROLE.
+	
+	Make sure to use either the button, or the `/roles add` command to add planetside2 and other game roles!
+	We play more than just planetside, but to keep the server tidy, they are hidden with roles."""
+
+	# Displayed when a user is choosing roles to ADD.
+	userAddingRoles = "Select the roles you wish to **ADD** using the dropdowns, then click update.\n\nDropdown is multiple choice."
+
+	# Displayed when a user is choosing roles to REMOVE.
+	userRemovingRoles = "Select the roles you wish to **REMOVE** using the dropdowns, then click Update."
+
+	# Operations Auto Move warning: Shown on Ops Notifications if autoMoveVC is enabled.
+	OpsAutoMoveWarn = "If you are already in a voice channel, you will be moved when the ops starts!"
+
+	# Ops Starting Soon: Message appended to Ops messages when the status is PRESTART.
+	OpsStartSoon = "This event is starting soon!  Sign up now to be considered a participant!"
+
+	# Ops Started: Message appended to Ops signup messages when the status is STARTED
+	OpsStarted = "Sorry, this event has already started and is no longer taking applicants!"
+
+	# Op Being Edited: Message appended to ops signup messages when being edited.
+	OpsBeingEdited = "This event is currently being edited, please wait to sign up!"
+
+	# Dismiss Editor: Shown when a user sends/updates an operation.
+	dismissEditor = "You may now dismiss the editor, if it hasn't automatically closed."
+
+	# Editor Error: shown when an error occured while posting an operation.
+	editorError = "An error occured while posting the message. Check all modified entries and try again.\nHint: Use the Keyboard Up arrow to retype the command with all but the opType pre-filled."
+
+	# No Matching PS2 Character name found, sent as a single message tagging participants, telling them no matching PS2 Char name is present.
+	noMatchingPS2Char = """No matching Planetside 2 Character was found with your current discord name.
+	If you wish for your statistics to be tracked, you can either:
+	 - Rename yourself to your Planetside2 Character.
+	 - Use `!About` and press `Setup`.
+	Make sure you do this BEFORE the event starts, otherwise you will not be tracked!
+	"""
+
+	# Not Being Tracked: Shown when users aren't being tracked on a non-PS2 event.
+	nonPS2TrackReqsNotMet = "This session won't be added to your session history!\nMake sure to be in the events voice channels before it starts to have it added."
+	
+	# Invalid Command Permission : Displayed to users who don't have the required permissions to run a command.
+	invalidCommandPerms = "You do not have the required permission to use that command!"
+
+	# Invalid Birthdate: Displayed to the user when they configure their userLibrary entry and provide an invalid birthdate.
+	invalidBirthdate = "The date provided was an invalid format. Make sure to include leading zeros (eg: 03/05), and if providing the year, ensure it's 4 digits not 2!."
+
+	# Feedback Overflow: Shown in feedback embeds if characters exceeds the max of 1024.
+	feedbackOverflow = "\n**UNABLE TO FIT ENTIRE FEEDBACK WITHIN EMBED!\nDownload Feedback to see it all.**"
+
+	# New Operation- Corrupt Data: Shown when adding a new Op but unable to read the default.
+	newOpCorruptData = "The default you tried to use is corrupt and has been removed.  Please try again using another default, or create a new one."
+
+	# COMMANDER AutoStart: Displayed on the commander when autostart is enabled.
+	commanderAutoStart = "Auto-Start is enabled.\n> *This Commander will automatically start the operation.*\n> *To start the operation early, press* ***START***."
+
+	# No Library Entry- Shown when someone tries to view a users library entry and there is none.
+	noUserEntry = "This user has no library entry. :("
+	
+	# No User Entry Self: Shown when a user tries to view their own entry and userAutoCreate is disabled.
+	NoUserEntrySelf = "You have no entry.  Ask an administrator to make one for you."
+
+	# No signed up Events: Shown to user when they use "show_events" and they're not in any.
+	noSignedUpEvents = f"You're not signed up to any events!\nUse the buttons below to jump to an event listing and sign up!"
+
+	# No Events: Similar to above, except there's no events.
+	noEvents = "There are no events to be signed up to."
+
+	# Feature Disabled: Shown when a command that depends on another feature is disabled.
+	featureDisabled = "That feature has been disabled."

--- a/src/botData/utilityData.py
+++ b/src/botData/utilityData.py
@@ -1,0 +1,84 @@
+# Similar to DataObjects, but specifically for Utility data objects.
+from enum import Enum
+import botUtils
+from discord import Colour
+
+class EmojiLibrary(Enum):
+	# Infantry Classes
+	ICON_LA  = "<:Icon_Light_Assault:795726936759468093>"
+	ICON_HA  = "<:Icon_Heavy_Assault:795726910344003605>"
+	ICON_ENG = "<:Icon_Engineer:795726888763916349>"
+	ICON_MED = "<:Icon_Combat_Medic:795726867960692806>"
+	ICON_INF = "<:Icon_Infiltrator:795726922264215612>"
+	ICON_MAX = "<:Icon_MAX:795726948365631559>"
+	# Ground Vehicles
+	ICON_ANT  = "<:Icon_ANT:795727784239824896>"
+	ICON_MBT  = "<:Icon_Vanguard:795727955896565781>"
+	ICON_TANK = "<:Icon_Lightning:795727852875677776>"
+	ICON_HAR  = "<:Icon_Harasser:795727814220840970>"
+	ICON_SUN  = "<:Icon_Sunderer:795727911549272104>"
+	# Air Vehicles
+	ICON_VAL = "<:Icon_Valkyrie:795727937735098388>"
+	ICON_GAL = "<:Icon_Galaxy:795727799591239760>"
+	ICON_LIB = "<:Icon_Liberator:795727831605837874>"
+	ICON_REA = "<:Icon_Reaver:795727893342846986>"
+	ICON_DER = "<:Icon_Dervish:861303237062950942>"
+	ICON_BAS = "<:Icon_Bastion:861304226957361162>"
+	# OTHER
+	ICON_GUNNER = "<:Icon_Infiltrator:795726922264215612>"
+
+	def ParseStringToEmoji(p_str:str):
+		"""
+		# PARSE STRING TO EMOJI
+		Returns the value of a given emoji name.
+		"""
+		for emote in EmojiLibrary:
+			if emote.name == p_str.upper():
+				botUtils.BotPrinter.Debug(f"Emoji {p_str} found in library!")
+				return emote.value
+		botUtils.BotPrinter.Debug(f"Name {p_str} does not match a emoji library entry.")
+		return "-" # Return the default "blank" so nothing breaks!
+
+
+class DateFormat(Enum):
+	"""
+	DATE FORMAT
+	Used within discord timeformat string to change how a POSIX datetime is displayed.
+	"""
+	Dynamic = ":R" # Dyanmically changes to most appropriate smallest stamp (in X days, in X hours, in x seconds)
+	DateShorthand = ":d" # dd/mm/year
+	DateLonghand = ":D" # 00 Month Year
+	TimeShorthand = ":t" # Hour:Minute
+	TimeLonghand = ":T" # Hour:Minute:Seconds
+	DateTimeShort = ":f" # Full date, no day.
+	DateTimeLong = ":F" # Full date, includes Day
+	Raw = "" # Raw POSIX.
+
+
+class Colours(Enum):
+	"""
+	# COLOURS:
+	Enum class of colours for use with discord objects.
+	"""
+	openSignup = Colour.from_rgb(0,244,0)
+	opsStarting = Colour.from_rgb(150, 0, 0)
+	opsStarted = Colour.from_rgb(255,0,0)
+	editing = Colour.from_rgb(204, 102, 0)
+	commander = Colour.from_rgb(0, 255, 360)
+	userRequest = Colour.from_rgb(106, 77, 255)
+	userWarnOkay = Colour.from_rgb(170, 255, 0)
+	userWarning = Colour.from_rgb(255, 85, 0)
+
+
+
+class ConsoleStyles:
+	"""
+	# CONSOLE STYLES
+	Class specifically for holding values for setting console formatting & colours.
+	"""
+	reset = "\033[0m"
+	bold = "\033[1m"
+	dim = "\033[2m"
+	colourWarn = "\033[31m"
+	ColourInfo = "\033[37m"
+	timeStyle = dim + ColourInfo

--- a/src/botUtils.py
+++ b/src/botUtils.py
@@ -1,0 +1,609 @@
+import os
+import sys
+import datetime
+import time
+from sys import stderr
+from botData.settings import BotSettings, CommandRestrictionLevels, Directories, Messages, Commander, NewUsers, SignUps, UserLib, CommandLimit, Roles, Channels
+from botData.dataObjects import EntryRetention
+import botData.utilityData as UtilityData
+import traceback
+import discord
+from discord.ext import commands
+# from botData import OperationData
+
+
+
+class Singleton(type):
+	"""
+	# SINGLETON
+
+	Used to ensure singletons via metaclasses.
+	"""
+	_instances = {}
+	def __call__(self, *arguments, **keywords):
+		if self not in self._instances:
+			self._instances[self] = super().__call__(*arguments, **keywords)
+		return self._instances[self]
+
+
+class BotPrinter():
+	"""
+	BOT PRINTER
+	Convenience class containing functions to print various information to console (and/or file).
+	"""
+
+	@staticmethod
+	def Debug(p_string):
+		"""
+		DEBUG
+		Prints a pre-formatted message to console IF ShowDebug is enabled.
+		"""
+		if(BotSettings.bDebugEnabled):
+			print(f"{UtilityData.ConsoleStyles.timeStyle}[{datetime.datetime.now()}] {p_string}{UtilityData.ConsoleStyles.reset} ")
+
+
+	@staticmethod
+	def Info(p_string):
+		"""
+		INFO
+		Similar to debug, but doesn't depend on ShowDebug to show.
+		Should ideally only be used for displaying status as to not flood the console.
+		"""
+		print(f"{UtilityData.ConsoleStyles.timeStyle}[{datetime.datetime.now()}]{UtilityData.ConsoleStyles.reset} {p_string}")
+
+
+	@staticmethod
+	def LogError(p_string:str, p_titleStr:str = ""):
+		"""
+		LOG ERROR
+		Displays an error to console.
+
+		p_titleString: String shown in alternate colour.
+		p_string : The message to show.
+		"""
+		print(f"{UtilityData.ConsoleStyles.timeStyle}[{datetime.datetime.now()}]{UtilityData.ConsoleStyles.reset} {UtilityData.ConsoleStyles.colourWarn}ERROR | {p_titleStr}{UtilityData.ConsoleStyles.reset} {UtilityData.ConsoleStyles.ColourInfo}{p_string}{UtilityData.ConsoleStyles.reset}", file=sys.stderr)
+
+
+	@staticmethod
+	def LogErrorExc(p_string: str, p_exception: Exception):
+		"""
+		Same as LOG ERROR, with addition of Exception parameter.
+		"""
+		print(f"{UtilityData.ConsoleStyles.timeStyle}[{datetime.datetime.now()}]{UtilityData.ConsoleStyles.reset} {UtilityData.ConsoleStyles.colourWarn}ERROR:{UtilityData.ConsoleStyles.reset} {UtilityData.ConsoleStyles.ColourInfo}{p_string} | {UtilityData.ConsoleStyles.reset}{ traceback.print_exc(limit=3)}", file=sys.stderr)
+
+
+
+
+
+# Used to clear up repeating code
+def GetPOSIXTime( pDate: datetime.datetime ):
+	return pDate.strftime("%s")	
+
+# Returns a specially formatted time for discord messages, defaults to dynamic type: "in X days. In 30 minutes" etc...
+def GetDiscordTime(pDate: datetime.datetime, pFormat: UtilityData.DateFormat = UtilityData.DateFormat.Dynamic):
+	return f"<t:{GetPOSIXTime(pDate)}{pFormat.value}>"
+
+
+class FilesAndFolders():
+	def SetupFolders():
+		"""
+		# SETUP FOLDERS:
+
+		Create the folders the bot uses.
+		"""
+		FilesAndFolders.GenerateDefaultOpsFolder()
+		FilesAndFolders.GenerateLiveOpsFolder()
+		FilesAndFolders.GenerateUserLibraryFolder()
+		FilesAndFolders.GenerateTempFolder()
+
+	def CleanupTemp():
+		"""
+		# CLEANUP TEMP
+		Removes the temp directory. Should only be called during shutdown.
+		"""
+		if not Directories.bCleanTempOnShutdown:
+			return
+
+		if os.path.exists(Directories.tempDir):
+			vFiles = FilesAndFolders.GetFiles(Directories.tempDir)
+			for fileName in vFiles:
+				try:
+					os.remove(f"{Directories.tempDir}{fileName}")
+				except OSError as vError:
+					BotPrinter.LogErrorExc(f"Unable to remove file: {fileName}", vError)
+
+
+
+	def DeleteCorruptFile(pDir: str):
+		BotPrinter.Info(f"Corrupt file being removed: {pDir}")
+		os.remove(pDir)
+
+
+	def GetFiles(pDir: str, pEndsWith: str = ""):
+		vDataFiles: list = []
+		for file in os.listdir(pDir):
+			if pEndsWith != "" and file.endswith(pEndsWith):
+				vDataFiles.append(file)
+
+			elif pEndsWith == "":
+				vDataFiles.append(file)
+
+		BotPrinter.Debug(f"Files ending with: {pEndsWith} In: {pDir} found:\n{vDataFiles}")
+		return vDataFiles
+
+
+	def GenerateDefaultOpsFolder():
+		BotPrinter.Debug("Creating default ops folder (if non existant)")
+		if (not os.path.exists( Directories.savedDefaultsDir ) ):
+			try:
+				os.makedirs(f"{ Directories.savedDefaultsDir }")
+			except OSError:
+				BotPrinter.LogError("Failed to create folder for default Ops data!")
+
+
+	def GenerateLiveOpsFolder():
+		BotPrinter.Debug("Creating live ops folder (if non existant)")
+		if (not os.path.exists( Directories.liveOpsDir ) ):
+			try:
+				os.makedirs(f"{ Directories.liveOpsDir }")
+			except OSError:
+				BotPrinter.LogError("Failed to create folder for Live Op data!")
+
+
+	def GenerateUserLibraryFolder():
+		BotPrinter.Debug("Creating User Library folder (if non existant)")
+		if (not os.path.exists( Directories.userLibrary ) ):
+			try:
+				os.makedirs(Directories.userLibrary)
+			except OSError:
+				BotPrinter.LogError("Failed to create folder for User Library!")
+
+		BotPrinter.Debug("Creating User Library: Recruits folder (if non existant)")
+		if (not os.path.exists( Directories.userLibraryRecruits ) ):
+			try:
+				os.makedirs(Directories.userLibraryRecruits)
+			except OSError:
+				BotPrinter.LogError("Failed to create folder for User Library!")
+
+
+
+	def GenerateTempFolder():
+		BotPrinter.Debug("Creating Temporary folder (if non existant).")
+		if (not os.path.exists( Directories.tempDir ) ):
+			try:
+				os.makedirs(f"{ Directories.tempDir }")
+			except OSError:
+				BotPrinter.LogError("Failed to create temporary folder!")
+
+
+	def GetOpFullPath(p_opFileName):
+		"""
+		Convenience function that returns a compiled string of botDir/OpsFolderName/{p_opFileName}.bin
+		
+		Do not use for DEFAULT ops:  
+		They use a different path!
+		"""
+		return f"{Directories.liveOpsDir}{p_opFileName}.bin"
+
+
+	def GetLockFilePath(p_opFileName):
+		"""
+		CONVENIENCE FUNCTION:
+		Returns a compiled string (liveOpsDir/p_opFileName.lockFileAffix) of a full path for opFile lock file.
+		"""
+		return f"{Directories.liveOpsDir}{p_opFileName}{Directories.lockFileAffix}"
+
+	
+	def GetLockPathGeneric(p_path):
+		"""
+		# GET LOCK PATH GENERIC
+		Returns a compiled string containing the given path and the lockfile affix. 
+		"""
+		return f"{p_path}{Directories.lockFileAffix}"
+
+
+	def IsLocked(p_opLockFile):
+		"""
+		IS LOCKED:
+		Checks if the file path given has an associated lock file. to prevent concurrent load/saving.
+
+		RETURNS: 
+		TRUE if a file is locked.
+		False if a file is lockable.
+		"""
+		# lockFile = f"{FilesAndFolders.GetOpsFolder}{p_opFileName}{settings.lockFileAffix}"
+		if (os.path.exists( p_opLockFile )):
+			return True
+		else:
+			return False
+
+
+	def GetLock(p_opLockFile):
+		"""
+		GET LOCK:
+		Creates a lock for a file.
+
+		NOTE: Will wait until any existing lock stops existing before creating.
+		"""
+		BotPrinter.Debug(f"Getting lock file for: {p_opLockFile}")
+		attempsLeft = 5
+		while FilesAndFolders.IsLocked(p_opLockFile):
+			if attempsLeft > 0:
+				time.sleep(0.2)
+				attempsLeft -= 1
+			else:
+				BotPrinter.Info(f"Attempted to get lock on file {p_opLockFile}, but ran out of attempts.")
+				return False
+
+		# No lock file exists!
+		BotPrinter.Debug(f"	-> Creating lock file... ")
+		return FilesAndFolders.CreateLock(p_opLockFile)
+
+
+	def CreateLock(p_opLockFile):
+		"""
+		CREATE LOCK:
+
+		NOTE Should not be called manually, use GetLock instead!
+		
+		Creates a lock file for the given Ops file.  
+
+		RETURNS
+		True - On success.
+		False - On Failure (exception)
+		"""
+		
+		try:
+			open(p_opLockFile, 'a').close()
+			return True
+		except OSError as vError:
+			BotPrinter.LogErrorExc("Failed to create LOCK file", vError)
+			return False
+
+
+	def ReleaseLock(p_fileToRelease:str) -> discord.guild.Guild:
+		"""
+		RELEASE LOCK:
+
+		Removes a lock file for the given File.
+		Should be called every time GETLOCK is called.
+		
+		RETURNS
+		True - On success (or file doens't exist)
+		False - On Failure (exception)
+		"""
+		BotPrinter.Debug(f"Releasing lock for {p_fileToRelease}")
+
+		if not p_fileToRelease.__contains__( Directories.lockFileAffix ):
+			BotPrinter.Debug("	-> File specified isn't a lock file!")
+			return False
+
+		if(FilesAndFolders.IsLocked(p_fileToRelease)):
+			try:
+				os.remove(p_fileToRelease)
+				BotPrinter.Debug(f"	-> Lock file released!")
+				return True
+			except OSError as vError:
+				BotPrinter.LogErrorExc("Failed to remove LOCK file", vError)
+				return False
+		BotPrinter.Debug("	-> No lock file present")
+		return True
+
+
+def GetGuildNF(p_botRef: commands.Bot) -> discord.Guild:
+	"""
+	# GET GUILD: No Fetch.
+	Similar to GetGuild, but does not fetch if no guild found.
+	
+	### RETURNS
+	The `discord.guild` using the id specified in settings or `none` if not found.
+	"""
+	BotPrinter.Debug("Getting Guild from ID.")
+	try:
+		guild = p_botRef.get_guild( BotSettings.discordGuild )
+		if guild != None:
+			return guild
+
+	except discord.Forbidden as vError:
+		BotPrinter.LogErrorExc("Bot has no access to this guild!", p_exception=vError)
+		return None
+
+	except discord.HTTPException:
+		BotPrinter.LogErrorExc("Unable to get guild.", p_exception=vError)
+		return None
+
+
+async def GetGuild(p_BotRef : commands.Bot):
+	"""
+	# GET GUILD:
+	
+	`p_BotRef`: A reference to the bot.
+
+	RETURNS: a discord.Guild using the ID from settings.
+
+	Tries get first, then fetch.
+	"""
+	BotPrinter.Debug("Getting Guild from ID.")
+	try:
+		guild = p_BotRef.get_guild(BotSettings.discordGuild )
+		if guild != None:
+			return guild
+
+		BotPrinter.Debug(f"	-> Failed to GET, attempting fetch instead.")
+		guild = await p_BotRef.fetch_guild( BotSettings.discordGuild)
+		if guild == None:
+			BotPrinter.Info("Unable to fetch guild!  Ensure you have the right ID.")
+			return None
+	
+		BotPrinter.Debug(f"Guild found with Fetch!  Chunked: {guild.chunked}")
+		return guild
+
+	except discord.Forbidden as vError:
+		BotPrinter.LogErrorExc("Bot has no access to this guild!", p_exception=vError)
+		return None
+
+	except discord.HTTPException:
+		BotPrinter.LogErrorExc("Unable to get guild.", p_exception=vError)
+		return None
+
+
+
+
+async def UserHasCommandPerms(p_callingUser:discord.Member, p_requiredLevel:CommandRestrictionLevels, p_interaction: discord.Interaction):
+	"""
+	# USER HAS VALID PERMS
+	Checks if the user provided has any role within restriction level.
+
+	NOTE: If `settings.bForceRoleRestrictions` is false, this always returns true.
+	"""
+	if not BotSettings.bForceRoleRestrictions:
+		return True
+
+	bHasPermission = UserHasPerms(p_callingUser, p_requiredLevel)
+	
+	if not bHasPermission and p_interaction != None:
+		await p_interaction.response.send_message(Messages.invalidCommandPerms, ephemeral=True)
+	
+	return bHasPermission
+
+
+
+def UserHasPerms(p_user:discord.Member, p_requiredLevel:CommandRestrictionLevels):
+	"""
+	# USER HAS PERMS
+	Similar to UserHasCommandPerms, except does not check `settings.bForceRoleRestrictions`.
+	Expected to be used outside of command/button checks, but still utilise the `CommandRestrictionLevels`.
+	"""
+	for role in p_user.roles:
+		if str(role.id) in p_requiredLevel.value or role.name in p_requiredLevel.value:
+			return True
+	
+	return False
+
+	
+
+
+class ChannelPermOverwrites():
+	"""
+	# CHANNEL PERM OVERWRITES
+	A class containing overwrite variables relating to the 4 restrictLevels, one `invisible` variable for hiding channels and a single function to set them (ideally on startup!).
+	"""
+	level0 = {}
+	level1 = {}
+	level2 = {}
+	level3 = {}
+	level3_readOnly = {}
+	invisible = {}
+	def __init__(self) -> None:
+		pass
+	
+	async def Setup(p_botRef:commands.Bot):
+		guild = await p_botRef.fetch_guild(BotSettings.discordGuild)
+		roles = await guild.fetch_roles()
+		# Defaults:
+
+		ChannelPermOverwrites.level3[guild.default_role] = discord.PermissionOverwrite(read_messages=False)
+
+		ChannelPermOverwrites.level2[guild.default_role] = discord.PermissionOverwrite(read_messages=False)
+
+		ChannelPermOverwrites.level1[guild.default_role] = discord.PermissionOverwrite(read_messages=False)
+
+		ChannelPermOverwrites.level0[guild.default_role] = discord.PermissionOverwrite(read_messages=False)
+
+		role : discord.Role
+		for role in roles:
+			# SETUP LEVEL 3
+			if role.name in CommandRestrictionLevels.level3.value or role.id in CommandRestrictionLevels.level3.value:
+				ChannelPermOverwrites.level3[role] = discord.PermissionOverwrite(
+					read_messages=True,
+					send_messages=True,
+					connect=True
+				)
+
+				ChannelPermOverwrites.invisible[role] = discord.PermissionOverwrite(
+					read_messages=False
+				)
+
+				ChannelPermOverwrites.level3_readOnly[role] = discord.PermissionOverwrite(
+					read_messages=True,
+					send_messages=False
+				)
+
+
+			# SEUP LEVEL 2
+			if role.name in CommandRestrictionLevels.level2.value or role.id in CommandRestrictionLevels.level2.value:
+				ChannelPermOverwrites.level2[role] = discord.PermissionOverwrite(
+					read_messages=True,
+					send_messages=True,
+					connect=True
+				)
+
+
+			# SEUP LEVEL 1
+			if role.name in CommandRestrictionLevels.level1.value or role.id in CommandRestrictionLevels.level1.value:
+				ChannelPermOverwrites.level1[role] = discord.PermissionOverwrite(
+					read_messages=True,
+					send_messages=True,
+					connect=True
+				)
+
+
+			# SEUP LEVEL 0
+			if role.name in CommandRestrictionLevels.level0.value or role.id in CommandRestrictionLevels.level0.value:
+				ChannelPermOverwrites.level0[role] = discord.PermissionOverwrite(
+					read_messages=True,
+					send_messages=True,
+					connect=True
+				)
+
+		BotPrinter.Info("ChannelPermOverwrites have been configured!")
+
+
+def PrintSettings(bGetOnly = False):
+	"""
+	# PRINT SETTINGS
+	To keep the settings file clean and easier to read, the printing is moved here.
+
+	Specify bGetOnly as TRUE to get the settings as a string instead.
+	"""
+	vString = "\n"
+
+
+	vString += "\nBOT DIRECTORY SETTINGS\n"
+	vString += f"	> Prefix Dir :	{Directories.prefixDir}\n"
+	vString += f"	> LiveOps Dir:	{Directories.liveOpsDir}\n" 
+	vString += f"	> DefaultsDir:	{Directories.savedDefaultsDir}\n" 
+	vString += f"	> UserLib Dir:	{Directories.userLibrary}\n"
+	vString += f"	> RecruitsDir:	{Directories.userLibraryRecruits}\n"
+	vString += f"	> LockFile Affix:	{Directories.lockFileAffix} | Retries: {Directories.lockFileRetry}\n"
+	vString += f"	> Feedback Prefix:	{Directories.feedbackPrefix}\n"
+	vString += f"	> Clean Temp Every:	{Directories.cleanTempEvery} hours ({Directories.cleanTempEvery/24} days)\n"
+	vString += f"	> Clean Temp On Shutdown: {Directories.bCleanTempOnShutdown}\n"
+
+
+	vString += "\nFEATURES\n"
+	vString += f"	> [{BotSettings.botFeatures.BotAdmin}] Bot Admin\n"
+	vString += f"	> [{BotSettings.botFeatures.NewUser}] New User\n"
+	vString += f"	> [{BotSettings.botFeatures.Operations}] Operations\n"
+	vString += f"	> [{BotSettings.botFeatures.UserLibrary}] User Library\n"
+	vString += f"		>> [{BotSettings.botFeatures.userLibraryInboxAdmin}] Inbox System | [{BotSettings.botFeatures.userLibraryInboxAdmin}] Inbox Admin | [{BotSettings.botFeatures.UserLibraryFun}] Fun Features\n"
+	vString += f"	> [{BotSettings.botFeatures.UserRoles}] User Roles\n"
+	vString += f"	> [{BotSettings.botFeatures.chatUtility}]  Chat Utility\n"
+	vString += f"	> [{BotSettings.botFeatures.ForFunCog}] For Fun Cog\n"
+
+
+	vString += "\nGENERAL BOT SETTINGS\n"
+	vString += f"	> DebugEnabled: {BotSettings.bDebugEnabled}\n"
+	token = BotSettings.discordToken[:5] # Always hide most of the token; shows JUST the first 5 characters.
+	vString += f"	> DiscordToken:	{token}...\n"
+	vString += f"	> DiscordGuild:	{BotSettings.discordGuild}\n"
+	token = BotSettings.ps2ServiceID[:5]
+	vString += f"	> PS2ServiceID:	{token}...\n"
+	vString += f"	> BotDirectory:	{BotSettings.botDir}\n"
+	vString += f"	> Can Purge BotAdmin: {BotSettings.bBotAdminCanPurge}\n"
+	if BotSettings.errorOutput == stderr:
+		vString += f"	> Error Output:	stderr\n"
+	else:
+		vString += f"	> Error Output:	{BotSettings.errorOutput}\n"
+	vString += f"	> Sanity Check Values: {BotSettings.bCheckValues}\n"
+	vString += f"\n	> Force Role Restrictions: {BotSettings.bForceRoleRestrictions}\n"
+	vString += f"	> Level 0:	{Roles.roleRestrict_level_0}\n"
+	vString += f"	> Level 1:	{Roles.roleRestrict_level_1}\n"
+	vString += f"	> Level 2:	{Roles.roleRestrict_level_2}\n"
+	vString += f"	> Level 3:	{Roles.roleRestrict_level_3}\n"
+
+
+	vString += "\nROLES\n"
+	vString += f"	> Recruit ID:		{Roles.recruit}\n"
+	vString += f"	> Promoted Role ID:	{Roles.recruitPromotion}\n"
+	vString += f"	> Auto Assign on Accept:{Roles.autoAssignOnAccept}\n"
+
+
+	vString += "\nCHANNELS\n"
+	vString += f"	> Bot Admin:	{Channels.botAdminID}\n"
+	vString += f"	> General:	{Channels.generalID}\n"
+	vString += f"	> PS2 Text:	{Channels.ps2TextID}\n"
+	vString += f"	> Rules:	{Channels.ruleID}\n"
+	vString += f"	> Gate:		{Channels.gateID}\n"
+	vString += f"	> Voice Fallback:{Channels.voiceFallback}\n"
+	vString += f"	> Event Moveback:{Channels.eventMovebackID}\n"
+	vString += f"	> Protected Categories:\n		> {Channels.protectedCategoriesID}\n"
+	vString += f"	> Quotes:	{Channels.quoteID}\n"
+	vString += f"	> Schedule {Channels.scheduleID}\n"
+
+
+
+	vString += f"\nCOMMAND LIMITS\n"
+	vString += f"	> Validate New User: {CommandLimit.validateNewuser.name}\n"
+	vString += f"	> User Roles: {CommandLimit.userRoles.name}\n"
+	vString += f"	> Op Manager:	{CommandLimit.opManager}\n"
+	vString += f"	> Op Commander: {CommandLimit.opCommander.name}\n"
+	vString += f"	> User Library: {CommandLimit.userLibrary.name}\n"
+	vString += f"	> User Library Admin: {CommandLimit.userLibraryAdmin.name}\n"
+	vString += f"	> Chat Utilities: {CommandLimit.chatUtilities.name}\n"
+
+
+
+	vString += "\nNEW USER SETTINGS\n"
+	vString += f"	> Rule Message:		{NewUsers.ruleMsgID}\n"
+	vString += f"	> Show AddRoles Button:	{NewUsers.bShowAddRolesBtn}\n"
+	vString += f"	> Create Library Entry on Accept: {NewUsers.bCreateLibEntryOnAccept}\n"
+	vString += f"\n	> Warnings: Discord Account age: {NewUsers.newAccntWarn} months\n"
+	vString += f"	> Warnings: Outfit Rank (Ord): {NewUsers.outfitRankWarn}\n"
+	vString += f"	> AutoLock PS2 Character on Accept: {NewUsers.bLockPS2CharOnAccept}\n"
+	vString += f"	> Purge Gate: {NewUsers.bPurgeGate}\n"
+
+
+
+	vString += "\nOP COMMANDER SETTINGS\n"
+	vString += f"	> Auto prestart:	{Commander.autoPrestart} minutes\n"
+	vString += f"	> Auto Start:		{Commander.bAutoStartEnabled}\n"
+	vString += f"	> Tracking Enabled: {Commander.bTrackingIsEnabled}"
+	vString += f"	> Tracking Interval:	{Commander.dataPointInterval} seconds\n"
+	vString += f"	> Marked Present:	{Commander.markedPresent.name}\n"
+	vString += f"	> Auto Alerts:		{Commander.bAutoAlertsEnabled}\n"
+	vString += f"	> Auto Alert count:	{Commander.autoAlertCount}\n"
+	vString += f"	> Auto Move VC:		{Commander.bAutoMoveVCEnabled}\n"
+	vString += f"	> Default Channels: {Commander.defaultChannels}\n"
+
+
+
+
+	vString += "\nSIGN UP SETTINGS\n"
+	vString += f"	> Parse Schedule: {SignUps.bAutoParseSchedule}\n"
+	vString += f"	> Parse Schedule timeout: {SignUps.autoParseTimeout}\n"
+	vString += f"	> Autoremove Outdated: {SignUps.bAutoRemoveOutdated}\n"
+	vString += f"	> Signup Cat  : {SignUps.signupCategory}\n"
+	vString += f"	> Resign Icon : {SignUps.resignIcon}\n" 
+	vString += f"	> Reserve Icon: {SignUps.reserveIcon}\n"
+	vString += f"	> Resign As Button : {SignUps.bResignAsButton}\n" 
+	vString += f"	> Auto Prestart:{SignUps.bAutoPrestartEnabled}\n"
+	vString += f"	> Show Opts in Footer: {SignUps.bShowOptsInFooter}\n"
+
+
+
+	vString += "\nUSER LIBRARY SETTINGS\n"
+	vString += f"	> Enforce PS2 Names:	{UserLib.bEnforcePS2Rename}\n"
+	vString += f"	> Special Users:	{UserLib.bEnableSpecialUsers}\n"
+	vString += f"	> User Inbox Enabled:	{UserLib.bEnableInbox}\n"
+	vString += f"	> Show jump buttons	for GetEvents:	{UserLib.bShowJumpButtonsForGetEvents}\n"
+	vString += f"	> Commander Create Entry: {UserLib.bCommanderCanAutoCreate}\n"
+	vString += f"	> User Self Create:	{UserLib.bUserCanSelfCreate}\n"
+	vString += f"	> Max Saved Events:	{UserLib.maxSavedEvents}\n"
+	vString += f"	> AutoPromote Users:	{UserLib.bAutoPromoteEnabled}\n"
+	vString += f"	> AutoPromote Rules:	{UserLib.autoPromoteRules}\n"
+	vString += f"	> AutoPromote Times:	{UserLib.autoQueryRecruitTime}\n"
+	vString += f"	> Max Session Previews:	{UserLib.sessionPreviewMax}\n"
+	vString += f"	> Max Sessions Browser:	{UserLib.sessionMaxPerPage}\n"
+	vString += f"	> Remove Entry/Special on leave: {UserLib.bRemoveEntryOnLeave}/{UserLib.bRemoveSpecialEntryOnLeave}\n"
+	vString += f"	> Library Data Memory Retention: {UserLib.entryRetention.name}\n"
+	if UserLib.entryRetention == EntryRetention.unloadAfter:
+		vString += f"		> Unload After: {UserLib.entryRetention_unloadAfter} | Check Interval {UserLib.entryRetention_checkInterval}\n"
+	vString += f"	> User Auto Sleeper: {UserLib.sleeperRules}\n"
+	if UserLib.sleeperRules.bIsEnabled:
+		vString += f"	> Sleeper Check Time: {UserLib.sleeperCheckTime}\n"
+
+	if bGetOnly:
+		return vString
+	else:
+		BotPrinter.Info(vString)

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,32 @@
+"""
+@author Michael O'Donnell & Lee Connor Williams
+
+https://github.com/Volumetric-Nanometre/planetside-discord-bot
+https://github.com/LCWilliams/planetside-discord-bot
+"""
+
+from planetsidebot import Bot
+import asyncio
+import asyncio_atexit
+
+from botUtils import FilesAndFolders
+from botUtils import BotPrinter as BUPrint
+from botData.settings import BotSettings
+
+FilesAndFolders.SetupFolders()
+
+ps2Bot = Bot()
+mainLoop = asyncio.get_event_loop()
+asyncio_atexit.register(callback=ps2Bot.ExitCalled, loop=mainLoop)
+
+try:
+	mainLoop.run_until_complete(ps2Bot.start(BotSettings.discordToken))
+except KeyboardInterrupt:
+	BUPrint.Info("Keyboard interrupt detected.")
+	pass
+finally:
+	mainLoop.close()
+	BUPrint.Info("Bot shutdown complete.")
+
+
+# asyncio.run( ps2Bot.run(BotSettings.discordToken), debug=BotSettings.bDebugEnabled)

--- a/src/planetsidebot.py
+++ b/src/planetsidebot.py
@@ -1,45 +1,76 @@
 """
 @author Michael O'Donnell
 """
-import os
 
 import discord
 from discord.ext import commands
-from dotenv import load_dotenv
-#import auraxium
-#from auraxium import ps2
-import asyncio
 
+import botUtils
+from botUtils import BotPrinter as BUPrint
+from botData import settings
 
-# internal modules
-import discordbasics
 import opstart
-import settings
 import opsignup
 import chatlinker
-import bullybully
-#import outfittracking
+
+from botData.sanityChecker import SanityCheck
+
 
 class Bot(commands.Bot):
 
     def __init__(self):
-        super(Bot, self).__init__(command_prefix=['!'])
+        discord.utils.setup_logging(root=False)
+        super().__init__(command_prefix=['!'], intents=discord.Intents.all())
+        
+        if settings.BotSettings.bShowSettingsOnStartup:
+            BUPrint.Info(f"Starting bot with settings:\n")
+            botUtils.PrintSettings()
 
-        self.add_cog(opstart.opschannels(self))
-        self.add_cog(opsignup.OpSignUp(self))
-        self.add_cog(chatlinker.ChatLinker(self))
-        #self.add_cog(bullybully.Bully(self))
-        #self.add_cog(outfittracking.PS2OutfitTracker(self))
+        self.vGuildObj: discord.Guild
+
+    async def setup_hook(self):
+        BUPrint.Info("Setting up hooks...")
+        # Needed for later functions, which want a discord object instead of a plain string.
+        self.vGuildObj = await botUtils.GetGuild(self)
+# COGS	
+        await self.add_cog(opstart.opschannels(self))
+        await self.add_cog(opsignup.OpSignUp(self))
+        await self.add_cog(chatlinker.ChatLinker(self))
+
+        self.tree.copy_global_to(guild=self.vGuildObj)
+        await self.tree.sync(guild=self.vGuildObj)
+
 
     async def on_ready(self):
-        print(f'Logged in as {self.user.name} | {self.user.id} on Guild {settings.DISCORD_GUILD}')
-bot = Bot()        
+        if settings.BotSettings.bCheckValues:
+            await SanityCheck.CheckAll(p_botRef=self)
+        
+        BUPrint.Info(f'\n\nBOT READY	|	{self.user.name} ({self.user.id}) on: {self.vGuildObj.name}\n')
 
-@bot.event
-async def on_command_error(ctx, error):
-    if isinstance(error, commands.errors.CheckFailure):
-        await ctx.send('You do not have the correct role for this command.')
-    
-print("loop running")
+        if settings.BotSettings.bShowSettingsOnStartup_discord:
+            vAdminChannel = self.get_channel(settings.Channels.botAdminID)
+            if vAdminChannel != None and settings.BotSettings.bShowSettingsOnStartup_discord:
+                vSettingStr = botUtils.PrintSettings(True)
+                splitString = [(vSettingStr[index:index+1990]) for index in range(0, len(vSettingStr), 1990)]
+                for segment in splitString:
+                    segment = f"```{segment}```"
+                    await vAdminChannel.send( f"{segment}\n" )
 
-bot.run(settings.DISCORD_TOKEN)
+
+
+    async def ExitCalled(self):
+        """
+		# EXIT CALLED
+		Called when an exit signal is sent.
+		"""
+        if self._closed:
+            return
+        vAdminChan = self.get_channel(settings.Channels.botAdminID)
+        if vAdminChan != None:
+            await vAdminChan.send("**Bot shutting down.**")
+
+        BUPrint.Info("Bot shutting down. Performing cleanup...")
+        botUtils.FilesAndFolders.CleanupTemp()
+
+        BUPrint.Info("Closing bot connections")
+        await self.close()

--- a/src/planetsidebot.py
+++ b/src/planetsidebot.py
@@ -9,6 +9,8 @@ import botUtils
 from botUtils import BotPrinter as BUPrint
 from botData import settings
 
+from userManager import UserLibraryCog, UserLibraryAdminCog, UserLibrary, UserLib_RecruitValidationRequest
+
 import opstart
 import opsignup
 import chatlinker
@@ -33,6 +35,11 @@ class Bot(commands.Bot):
         # Needed for later functions, which want a discord object instead of a plain string.
         self.vGuildObj = await botUtils.GetGuild(self)
 # COGS	
+        if settings.BotSettings.botFeatures.UserLibrary:
+            await self.add_cog(UserLibraryCog(self))
+            await self.add_cog(UserLibraryAdminCog(self))
+
+
         await self.add_cog(opstart.opschannels(self))
         await self.add_cog(opsignup.OpSignUp(self))
         await self.add_cog(chatlinker.ChatLinker(self))
@@ -44,7 +51,10 @@ class Bot(commands.Bot):
     async def on_ready(self):
         if settings.BotSettings.bCheckValues:
             await SanityCheck.CheckAll(p_botRef=self)
-        
+
+        # Objects with BOT refs
+        UserLibrary.botRef = self
+
         BUPrint.Info(f'\n\nBOT READY	|	{self.user.name} ({self.user.id}) on: {self.vGuildObj.name}\n')
 
         if settings.BotSettings.bShowSettingsOnStartup_discord:

--- a/src/userManager.py
+++ b/src/userManager.py
@@ -862,7 +862,7 @@ class UserLibrary():
 					bPromote = False
 
 
-		if not bPromote:
+		if not bPromote and not p_asBool:
 			BUPrint.Debug("Not promoting user.")
 			return vRequirementsMsg
 		

--- a/src/userManager.py
+++ b/src/userManager.py
@@ -766,7 +766,10 @@ class UserLibrary():
 				renameStr += f" [{vOutfit.alias}]"
 
 			BUPrint.Info(f"{discordMember.name} provided PS2 character name in UserLib setup. Renaming user to: {renameStr}")
-			await discordMember.edit(nick=renameStr)
+			try:
+				await discordMember.edit(nick=renameStr)
+			except discord.Forbidden:
+				BUPrint.Info(f"Bot does not have the required privileges to rename {discordMember.display_name}")
 
 		return True
 
@@ -1629,12 +1632,12 @@ class LibViewer_ConfigureModal(discord.ui.Modal):
 
 		if self.vUserEntry.ps2Name != "" and not self.vUserEntry.settings.bLockPS2Char:
 			self.txt_ps2Char.placeholder = self.vUserEntry.ps2Name
-		elif self.vUserEntry.settings.bLockPS2Char:
+		elif self.vUserEntry.settings.bLockPS2Char and not self.bIsAdminEdit:
 			self.remove_item(self.txt_ps2Char)
 		
 		if self.vUserEntry.aboutMe != "" and not self.vUserEntry.settings.bLockAbout:
 			self.txt_about.default = self.vUserEntry.aboutMe
-		elif self.vUserEntry.settings.bLockAbout:
+		elif self.vUserEntry.settings.bLockAbout and not self.bIsAdminEdit:
 			self.remove_item(self.txt_about)
 
 		if self.vUserEntry.birthday != None:

--- a/src/userManager.py
+++ b/src/userManager.py
@@ -1,0 +1,1780 @@
+# USER MANAGER: Holds the content for the User Library classes.
+from __future__ import annotations
+
+import discord
+import discord.ext
+from discord.ext import commands, tasks
+
+from discord import app_commands
+
+from auraxium import Client as AuraxClient
+import auraxium.ps2 as AuraxPS2
+
+import os
+
+import pickle
+
+from datetime import datetime, timezone, timedelta
+
+from enum import Enum
+
+from botUtils import BotPrinter as BUPrint
+from botUtils import FilesAndFolders, GetDiscordTime, UserHasCommandPerms, GetGuildNF
+
+from botData.dataObjects import User, Session, OpsStatus, LibraryViewPage, UserInboxItem, EntryRetention
+
+from botData.utilityData import DateFormat
+
+import botData.settings as settings
+
+
+
+
+class UserLibraryCog(commands.GroupCog, name="user_library"):
+	"""
+	# USER LIBRARY COG
+	Commands related to the user library, for regular users.
+	"""
+	def __init__(self, p_botRef:commands.Bot):
+		self.botRef = p_botRef
+		BUPrint.Info("COG: User Library loaded!")
+		if settings.UserLib.topQuoteReactions > 0 and settings.BotSettings.botFeatures.UserLibraryFun:
+			self.botRef.add_listener(self.CheckReactions, "on_raw_reaction_add")
+			self.botRef.add_listener(self.CheckReactions, "on_raw_reaction_remove")
+
+
+	@app_commands.command(name="about", description="Show information about a user, or see your own!")
+	@app_commands.describe(p_userToFind="The user you want to see information about;  Leave empty to see your own!")
+	@app_commands.rename(p_userToFind="user")
+	async def AboutUser(self, p_interaction:discord.Interaction, p_userToFind:discord.Member = None):
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, (settings.CommandLimit.userLibrary), p_interaction):
+			return
+		userID = -1
+
+		bViewingSelf = bool(p_userToFind == None or p_userToFind.id == p_interaction.user.id)
+
+		if bViewingSelf:
+			userID = p_interaction.user.id
+		else:
+			userID = p_userToFind.id
+
+		if UserLibrary.HasEntry(userID):
+			vLibViewer = LibraryViewer(userID, bViewingSelf)
+			await vLibViewer.SendViewer(p_interaction)
+	
+		elif not bViewingSelf:
+			await p_interaction.response.send_message(settings.Messages.noUserEntry, ephemeral=True)
+	
+		elif settings.UserLib.bUserCanSelfCreate:
+			newEntry = User(discordID=p_interaction.user.id)
+			UserLibrary.SaveEntry(newEntry)
+			
+			vLibViewer = LibraryViewer(p_interaction.user.id, True)
+			await vLibViewer.SendViewer(p_interaction)
+		
+		else:
+			await p_interaction.response.send_message(settings.Messages.NoUserEntrySelf)
+
+	
+
+
+
+
+	async def CheckReactions(self, p_data:discord.RawReactionActionEvent):
+		if p_data.channel_id != settings.Channels.quoteID:
+			# Not correct channel.
+			return
+
+		bQuoteExists = False
+		quoteChanel = self.botRef.get_channel( p_data.channel_id )
+		vMessage = await quoteChanel.fetch_message( p_data.message_id )
+
+		if vMessage == None:
+			BUPrint.LogError("Unable to get Quote Channel Message", "FETCH FAILED")
+			return
+		
+		if len(vMessage.mentions) == 0:
+			BUPrint.Debug("No mentions, unable to get quotee.")
+			return
+		
+		vQuotedUser = vMessage.mentions[0]
+
+		if not UserLibrary.HasEntry(vQuotedUser.id):
+			BUPrint.Debug("User has no entry. Unable to update it.")
+			return
+
+		vUserLibEntry = UserLibrary.LoadEntry(vQuotedUser.id) 
+
+		# Determine if quote exists already:
+		existingQuote:str = str("")
+		for quote in vUserLibEntry.topQuotes:
+			if vMessage.content == quote:
+				bQuoteExists = True
+				existingQuote = quote
+
+
+		# Get total reaction count.
+		vTotalReactions = 0
+		for reaction in vMessage.reactions:
+			vTotalReactions += reaction.count
+
+
+		if vTotalReactions < settings.UserLib.topQuoteReactions and bQuoteExists:
+			BUPrint.Debug("Minimum quote threshold not reached, removing existing quote.")
+			try:
+				vUserLibEntry.topQuotes.remove(existingQuote)
+				UserLibrary.SaveEntry(vUserLibEntry)
+			except ValueError:
+				BUPrint.LogError(p_titleStr="Unable to remove existing quote", p_string="Unable to remove matching entry from list.")
+			return
+
+
+		if vTotalReactions >= settings.UserLib.topQuoteReactions and not bQuoteExists:
+			BUPrint.Debug("Quote threshold reached, adding quote!")
+			if len(vUserLibEntry.topQuotes) == settings.UserLib.maxQuotes:
+				BUPrint.Debug("Reached max quote count, removing oldest...")
+				# Remove oldest top quote.
+				vUserLibEntry.topQuotes.pop(-1)
+
+			if not bQuoteExists:
+				vUserLibEntry.topQuotes.append(vMessage.content)
+			UserLibrary.SaveEntry(vUserLibEntry)
+			return
+
+
+
+class UserLibraryAdminCog(commands.GroupCog, name="userlib_admin"):
+	"""
+	# USER LIBRARY ADMIN COG
+	Administrative commands and listeners for managing the user library.
+	"""
+	def __init__(self, p_botRef):
+		self.adminLevel = settings.CommandLimit.userLibraryAdmin
+		self.botRef:commands.Bot = p_botRef
+		self.userLibRetentionTask = None
+		self.querySleeperTask = None
+
+		if settings.BotSettings.botFeatures.UserLibrary:
+			self.contextMenu_setAsRecruit = app_commands.ContextMenu(
+				name="Set as Recruit",
+				callback=self.SetUserAsRecruit
+			)
+			self.botRef.tree.add_command(self.contextMenu_setAsRecruit)
+
+
+			if settings.BotSettings.botFeatures.userLibraryInboxSystem and settings.BotSettings.botFeatures.userLibraryInboxAdmin:
+				self.contextMenu_warnMessage = app_commands.ContextMenu(
+					name="Warn user about message",
+					callback=self.SendUserMessageWarning
+				)
+
+				self.contextMenu_warnUser = app_commands.ContextMenu(
+					name="Warn user",
+					callback=self.SendUserWarning
+				)
+				self.botRef.tree.add_command(self.contextMenu_warnUser)
+				self.botRef.tree.add_command(self.contextMenu_warnMessage)
+
+
+			if settings.UserLib.entryRetention == EntryRetention.unloadAfter:
+				self.userLibRetentionTask = tasks.Loop(
+					coro=self.CheckEntryRetention,
+					seconds=None, hours=None,
+					minutes=settings.UserLib.entryRetention_checkInterval,
+					time=None, count=None, reconnect=True
+				)
+
+				self.userLibRetentionTask.start()
+
+
+			if settings.UserLib.sleeperRules.bIsEnabled:
+				self.querySleeperTask = tasks.Loop(
+					coro=self.CheckSleepingUsers,
+					time=settings.UserLib.sleeperCheckTime,
+					seconds=None, hours=None, minutes=None,
+					count= None, reconnect=True
+				)
+				self.querySleeperTask.start()
+				
+
+
+
+		BUPrint.Info("COG: User Library Admin loaded!")
+
+
+
+	async def cog_unload(self) -> None:
+		self.botRef.tree.remove_command(self.contextMenu_setAsRecruit)
+		self.botRef.tree.remove_command(self.contextMenu_warnMessage)
+		self.botRef.tree.remove_command(self.contextMenu_warnUser)
+		return await super().cog_unload()
+
+
+	# CONTEXT MENU COMMANDS
+	async def SetUserAsRecruit(self, p_interaction:discord.Interaction, p_User:discord.Member):
+		"""
+		# SET USER AS RECRUIT
+		Context menu option that changes a user to a recruit.
+		"""
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return		
+		
+		vRecruitRole = p_interaction.guild.get_role(settings.Roles.recruit)
+		vNormalRole = p_interaction.guild.get_role(settings.Roles.recruitPromotion)
+		vUserEntry = UserLibrary.LoadEntry( p_User.id )
+		vResultMessage = ""
+
+		if vRecruitRole != None:
+			try:
+				await p_User.add_roles(vRecruitRole, reason=f"{p_interaction.user.display_name} set {p_User.display_name} to recruit.")
+				await p_User.remove_roles(vNormalRole, reason=f"{p_interaction.user.display_name} set {p_User.display_name} to recruit.")
+
+			except discord.Forbidden:
+				vResultMessage += "Bot has invalid permissions.\n"
+			except discord.HTTPException:
+				vResultMessage += "Discord failed to update roles.\n"
+
+		if vUserEntry == None:
+			vUserEntry = User(discordID=p_User.id)
+			vResultMessage += "User had no library entry! Entry was created.\n"
+		
+		vUserEntry.bRecruitRequestedPromotion = False
+		vUserEntry.bIsRecruit = True
+		vResultMessage += f"User library for {p_User.display_name} has been updated."
+
+		UserLibrary.SaveEntry(vUserEntry)
+		vAdminChn = p_interaction.guild.get_channel( settings.Channels.botAdminID )
+
+		if vAdminChn != None:
+			try:
+				await vAdminChn.send(vResultMessage)
+			except (discord.errors.NotFound, discord.errors.HTTPException):
+				BUPrint.Info(vResultMessage)
+		else:
+			BUPrint.Info(vResultMessage)
+
+		await p_interaction.response.send_message("Sucessfully made user a recruit!", ephemeral=True)
+
+
+
+	async def SendUserWarning(self, p_interaction:discord.Interaction, p_User:discord.Member):
+		"""
+		# SEND USER WARNING
+		Context menu option that sends a warning message to the user via the library inbox.
+		"""
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return
+
+		await p_interaction.response.send_modal(SendWarningModal(p_User.id, ""))
+		
+
+	async def SendUserMessageWarning(self, p_interaction:discord.Interaction, p_message:discord.Message):
+		"""
+		# SEND USER WARNING: MESSAGE
+		Context menu option that sends a warning regarding a message to the user via the library inbox.
+		"""
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return
+
+		await p_interaction.response.send_modal(SendWarningModal(p_message.author.id, p_message.content))
+
+
+	async def CheckEntryRetention(self):
+		vRemoveDate = datetime.now(tz=timezone.utc)
+		for entry in UserLibrary.loadedEntries.values():
+			if entry.lastAccessed + timedelta(minutes=settings.UserLib.entryRetention_unloadAfter) > vRemoveDate:
+				BUPrint.Debug(f"User Entry: {entry.discordID} unloaded from library.")
+				del UserLibrary.loadedEntries[entry.discordID]
+
+
+	async def CheckSleepingUsers(self):
+		"""# CHECK SLEEPING USERS
+		Loads all saved entries and queries if users are asleep"""
+
+		allEntries = UserLibrary.GetAllEntries()
+		sleeperRole = GetGuildNF(self.botRef).get_role(settings.Roles.sleeperRoleID)
+
+		BUPrint.Info("Querying member sleep/awake...")
+		for entry in allEntries:
+			await UserLibrary.QuerySleeper(entry, sleeperRole)
+
+		BUPrint.Info("Query finished!")
+
+
+
+# # # NORMAL COMMANDS
+	@app_commands.command(name="edit_user", description="Opens the Edit modal for the specified user entry, if they have one.")
+	@app_commands.describe(p_userToEdit="Choose the user to edit.", p_createNew="If no entry exists, create a new entry (Default: True)")
+	@app_commands.rename(p_userToEdit="user", p_createNew="create_if_none")
+	async def ConfigureUser(self, p_interaction:discord.Interaction, p_userToEdit:discord.Member, p_createNew:bool = True):
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return
+
+		if p_userToEdit == None:
+			await p_interaction.response.send_message("Invalid user!", ephemeral=True)
+			return
+
+
+		vEntry = None
+		if UserLibrary.HasEntry(p_userToEdit.id):
+			vEntry = UserLibrary.LoadEntry(p_userToEdit.id)
+
+		elif p_createNew:
+			vEntry = User( discordID=p_userToEdit.id )
+		
+		if vEntry != None:
+			await p_interaction.response.send_modal( LibViewer_ConfigureModal(p_adminEditEntry=vEntry) )
+		else:
+			await p_interaction.response.send_message("No entry was found. If you want to create a new one, ensure `Create_if_none` is true (default!)")
+
+
+
+	@app_commands.command(name="get_recruits", description="Returns a message containing recruits and their statistics.")
+	async def GetRecruits(self, p_interaction:discord.Interaction):
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return
+
+		await p_interaction.response.defer(ephemeral=True, thinking=True)
+		
+
+		vRecruitEntries = UserLibrary.GetRecruitEntries()
+
+		if vRecruitEntries == None:
+			await p_interaction.response.send_message("No user entries are saved.", ephemeral=True)
+			return
+
+
+		if len(vRecruitEntries) == 0:
+			await p_interaction.response.send_message("No recruits found.", ephemeral=True)
+			return
+
+		vMessage = f"**RECRUITS ({len(vRecruitEntries)})**"
+
+		for entry in vRecruitEntries:
+			vUser = p_interaction.guild.get_member( entry.discordID )
+			vMessage += f"\n\n{vUser.mention}:\n{UserLibrary.GetRecruitRequirements(entry)}"
+
+		await p_interaction.edit_original_response(content=vMessage)
+
+
+	@app_commands.command(name="create_missing_entries", description="Creates library entries for general users without them.")
+	@app_commands.describe(bOutfitOnly="(Default: True) If false, creates entries for all users regardless of whether they're part of the outfit.")
+	@app_commands.rename(bOutfitOnly="only_outfit")
+	async def CreateMissingEntries(self, p_interaction:discord.Interaction, bOutfitOnly:bool = True):
+		# HARDCODED ROLE USEAGE:
+		if not await UserHasCommandPerms(p_interaction.user, self.adminLevel, p_interaction):
+			return
+
+		await p_interaction.response.defer(thinking=True, ephemeral=True)
+
+		# HARDCODED ADMIN: to prevent the command iterating over everyone, only the bot admin(s) can run this command with outfitOnly on false.
+		if not bOutfitOnly and p_interaction.user.id not in settings.Roles.roleRestrict_ADMIN:
+			await p_interaction.edit_original_response(content="You do not have permission to run this command with `outfit_only` on false.")
+			return
+
+		BUPrint.Info("Creating entries for missing users...")
+		entriesCreated = 0
+		for member in p_interaction.guild.members:
+			memberRoleIDs = [role.id for role in member.roles]
+			bIsOutfitMember = bool(settings.Roles.recruit in memberRoleIDs or settings.Roles.recruitPromotion in memberRoleIDs)
+			if not bIsOutfitMember and bOutfitOnly:
+				BUPrint.Debug(f"{member.display_name} not part of outfit, and command is running: outfit only. Skipping")
+				continue
+
+			if not UserLibrary.HasEntry(member.id):
+				BUPrint.Debug(f"{member.display_name} had no entry, creating one.")
+
+				newEntry = User(discordID=member.id)
+				UserLibrary.SaveEntry(newEntry)
+				entriesCreated += 1
+
+		await p_interaction.edit_original_response(content=f"Task completed. {entriesCreated} entries created.")
+	
+
+
+	@commands.Cog.listener("on_raw_member_remove")
+	async def UserLeft(self, p_Event:discord.RawMemberRemoveEvent):
+		"""
+		# USER LEFT
+		Listener function, if the appropriate settings are set, removes the User Library entry files.
+		"""
+		BUPrint.Info(f"User {p_Event.user.display_name} has left.  Removing Entry:Special - {settings.UserLib.bRemoveEntryOnLeave}:{settings.UserLib.bRemoveSpecialEntryOnLeave}")
+
+		if settings.UserLib.bRemoveEntryOnLeave:
+			BUPrint.Info(f"User {p_Event.user.display_name} has left, removing their library entries.")
+			UserLibrary.RemoveEntry(p_Event.user.id, settings.UserLib.bRemoveSpecialEntryOnLeave)
+
+	
+	@tasks.loop(time=settings.UserLib.autoQueryRecruitTime)
+	async def AutoQueryRecruits(self):
+		BUPrint.Info("Automatic query of all recruits starting...")
+		await UserLibrary.QueryAllRecruits()
+
+
+
+
+class SendWarningModal(discord.ui.Modal):
+	"""# SEND WARNING MODAL:
+	A modal used by admins to send a warning to a users inbox.  Used for both member and message based menus.
+	"""
+	txt_messageTitle = discord.ui.TextInput(
+		label="Title",
+		style=discord.TextStyle.short,
+		required=True,
+		placeholder="Few word summary",
+		max_length=50
+	)
+
+	txt_messageToSend = discord.ui.TextInput(
+		label="Message",
+		style=discord.TextStyle.long,
+		placeholder="A message that should tell the user why they were warned",
+		max_length=800
+	)
+
+	def __init__(self, p_userID:int, p_flaggedMessage:str):
+		self.userID = p_userID
+		self.flaggedMsg = p_flaggedMessage
+		super().__init__(title="Send warning", custom_id=f"warningTo_{p_userID}")
+
+	async def on_submit(self, p_interaction:discord.Interaction):
+		userEntry:User = None
+		if not UserLibrary.HasEntry(self.userID):
+			userEntry = User(discordID=self.userID)
+			UserLibrary.SaveEntry(userEntry)
+		else:
+			userEntry = UserLibrary.LoadEntry(self.userID)
+
+		inboxItem = UserInboxItem(
+			date=datetime.now(timezone.utc),
+			adminContext=self.flaggedMsg[:150],
+			title=self.txt_messageTitle.value,
+			bIsWarning=True,
+			message=self.txt_messageToSend.value
+		)
+		
+		await UserLibrary.SendNewInboxMessage(userEntry, inboxItem)
+
+		await p_interaction.response.send_message("Warning sent succesfully.", ephemeral=True)
+
+
+
+
+class UserLibrary():
+	"""
+	# USER LIBRARY OBJECT
+	Contains functions relating to the entries.
+	Functions will not require an instance.
+	"""
+	botRef:commands.Bot
+	loadedEntries: dict[int, User] = {}
+	def __init__(self):
+		pass
+
+
+
+	def GetEntryPath(p_userID:int):
+		"""
+		# GET ENTRY PATH
+		Convenience function to return a pre-compiled path of an entry.
+		"""
+		return f"{settings.Directories.userLibrary}{p_userID}.bin"
+
+
+
+	def GetRecruitEntryPath(p_userID:int):
+		"""
+		# GET ENTRY PATH: RECRUIT
+		Same as GetEntryPath, but for recruits.
+		"""
+		return f"{settings.Directories.userLibraryRecruits}{p_userID}.bin"
+
+
+
+	def HasEntry(p_UserID:int):
+		"""
+		# HAS LIBRARY ENTRY
+		Checks if an entry (both normal and recruits) for the user ID exists.
+
+		### RETURNS
+		`True` if an entry exists.
+
+		`False` if no entry exists.
+		"""
+		if os.path.exists(f"{UserLibrary.GetEntryPath(p_UserID)}"):
+			return True
+
+		if os.path.exists(f"{UserLibrary.GetRecruitEntryPath(p_UserID)}"):
+			return True
+
+		return False
+
+
+
+	def IsRecruitEntry(p_userID:int):
+		"""
+		# IS RECRUIT ENTRY
+		Checks if a file exists for a user in recruit directory.
+		Typically used after HasEntry to determine the entry type.
+		"""
+		if os.path.exists(f"{UserLibrary.GetRecruitEntryPath(p_userID)}"):
+			return True
+		else:
+			return False
+
+
+
+	def SaveEntry(p_entry:User):
+		"""
+		# SAVE LIBRARY ENTRY
+		Saves the passed entry to file.
+		"""
+		vFilePath = ""
+		vLockFile = ""
+
+		# Recruits User entry is saved in wrong directory, remove it.
+		if p_entry.bIsRecruit and os.path.exists(UserLibrary.GetEntryPath(p_entry.discordID)):
+			try:
+				vFilePath = UserLibrary.GetEntryPath(p_entry.discordID)
+				os.remove(vFilePath)
+			except OSError as vError:
+				BUPrint.LogError(f"Unable to remove recruit entry file from wrong directory! \n{vError.strerror}",0)
+
+			if os.path.exists(UserLibrary.GetEntryPath(p_entry.discordID).replace(".bin", ".txt")):
+				vSpecialPath = vFilePath.replace(".bin", ".txt")
+				try:
+					os.remove(vSpecialPath)
+				except OSError as vError:
+					BUPrint.LogError(f"Unable to remove recruit special entry file from wrong directory! \n{vError.strerror}",0)
+
+		# Get appropriate path:
+		if p_entry.bIsRecruit:
+			BUPrint.Debug("Saving recruit entry.")
+			vFilePath = UserLibrary.GetRecruitEntryPath(p_entry.discordID)
+		else:
+			BUPrint.Debug("Saving normal entry.")
+			vFilePath = UserLibrary.GetEntryPath(p_entry.discordID)
+
+
+		vLockFile = FilesAndFolders.GetLockPathGeneric(vFilePath)
+		FilesAndFolders.GetLock(vLockFile)
+
+		# Set KeepLoaded bool to current value to be reset afterwards.
+		bKeepLoaded = p_entry.bKeepLoaded
+		p_entry.bKeepLoaded = False
+
+		try:
+			with open(vFilePath, "wb") as vFile:
+				pickle.dump(p_entry, vFile)
+
+			FilesAndFolders.ReleaseLock(vLockFile)
+		except pickle.PickleError as vError:
+			BUPrint.LogErrorExc("Unable to load user entry", vError)
+			FilesAndFolders.ReleaseLock(vLockFile)
+			return
+
+		
+		if p_entry.specialAbout == "":
+			return
+
+		vSpecialPath = vFilePath.replace(".bin", ".txt")
+		try:
+			with open(vSpecialPath, "wt") as vSpecialFile:
+				vSpecialFile.write(p_entry.specialAbout)
+		except OSError as vError:
+			BUPrint.LogErrorExc("Unable to load special entry", vError)
+
+		p_entry.bKeepLoaded = bKeepLoaded
+		p_entry.lastAccessed = datetime.now(tz=timezone.utc)
+
+
+
+	def LoadEntry(p_userID:int):
+		"""
+		# LOAD LIBRARY ENTRY
+		If an entry exists, it is loaded and returned.
+
+		### RETURNS:
+		`User` library entry, or `None` if not found.
+		"""
+		vLibEntry:User = None
+
+		BUPrint.Debug(f"Loading Library Entry: {p_userID}")
+		if not UserLibrary.HasEntry(p_userID):
+			BUPrint.Debug(f"User with id {p_userID} has no library entry")
+			return None
+
+
+		if p_userID in UserLibrary.loadedEntries:
+			vLibEntry = UserLibrary.loadedEntries.get(p_userID)
+			vLibEntry.lastAccessed = datetime.now(tz=timezone.utc)
+			return vLibEntry
+
+
+		bIsRecruit = UserLibrary.IsRecruitEntry(p_userID)
+		vFilePath = ""
+
+		if bIsRecruit:
+			vFilePath = UserLibrary.GetRecruitEntryPath(p_userID)
+		else:
+			vFilePath = UserLibrary.GetEntryPath(p_userID)
+
+		vLockFile = FilesAndFolders.GetLockPathGeneric(vFilePath)
+		FilesAndFolders.GetLock(vLockFile)
+
+		try:
+			with open(vFilePath, "rb") as vFile:
+				vLibEntry = pickle.load(vFile)
+
+			FilesAndFolders.ReleaseLock(vLockFile)
+
+		except pickle.PickleError as vError:
+			BUPrint.LogErrorExc("Unable to load user entry", vError)
+			FilesAndFolders.ReleaseLock(vLockFile)
+			return None
+		except ModuleNotFoundError as vError:
+			BUPrint.LogErrorExc("Module Not Found! Most likely due to changing data structure.")
+			FilesAndFolders.ReleaseLock(vLockFile)
+
+		vSpecialPath = vFilePath.replace(".bin", ".txt")
+		if os.path.exists(vSpecialPath):
+			try:
+				with open(vSpecialPath, "rt") as vSpecialFile:
+					vLibEntry.specialAbout = vSpecialFile.read()
+			except OSError as vError:
+				BUPrint.LogErrorExc("Unable to load special entry", vError)
+
+
+		if settings.UserLib.entryRetention != EntryRetention.whenNeeded:
+			vLibEntry.lastAccessed = datetime.now(tz=timezone.utc)
+			UserLibrary.loadedEntries[vLibEntry.discordID] = vLibEntry
+
+		return vLibEntry
+
+
+
+	def GetAllEntries() -> list[User]:
+		"""
+		# GET ALL ENTRIES
+		Loads all entries and returns them in a list.
+
+		NOTE: Extension is stripped.
+
+		NOTE: This does NOT load all entries into the library's dictionary.
+		"""
+		vEntryList = []
+		files = FilesAndFolders.GetFiles(settings.Directories.userLibrary, ".bin")
+		files += FilesAndFolders.GetFiles(settings.Directories.userLibraryRecruits, ".bin")
+
+		file:str
+		for file in files:
+			vEntryList.append( UserLibrary.LoadEntry(file.replace(".bin", "")) )
+
+		return vEntryList
+
+
+
+	async def SendNewInboxMessage(p_entry:User, p_message:UserInboxItem):
+		"""# SEND NEW INBOX MESSAGE
+		Adds the inbox item to user entry, then sends a notification.
+		"""
+
+		vMember = UserLibrary.botRef.get_user(p_entry.discordID)
+		vChannel = UserLibrary.botRef.get_channel(settings.Channels.generalID)
+
+		p_entry.inbox.append(p_message)
+		UserLibrary.SaveEntry(p_entry)
+
+		newView = discord.ui.View()
+		newView.add_item(LibViewer_btnViewInbox(p_entry.discordID))
+
+		if vMember != None and vChannel != None:
+			await vChannel.send(content=f"{vMember.mention}, you have a new message in your inbox!", view=newView)
+
+
+
+	def GetRecruitEntries():
+		"""
+		# GET RECRUIT ENTRIES
+		Similar to get all entries; returns a list of entries.  
+		The returned list of this function only includes recruits.
+		"""
+		vEntryList:list[User] = []
+
+		files = FilesAndFolders.GetFiles(settings.Directories.userLibraryRecruits, ".bin")
+
+		file:str
+		for file in files:
+			vEntryList.append( UserLibrary.LoadEntry(file.replace(".bin", "")) )
+
+		return vEntryList
+
+
+
+	async def PropogatePS2Info(p_entry:User):
+		"""
+		# PROPGATE PS2 INFO
+		Uses the AuraxClient to check valid PS2 name and set the PS2 details accordingly.
+
+		### RETURN
+		False on failure to find a character.
+
+		True if character is found.
+		"""
+
+		if p_entry.ps2Name == "":
+			return False
+		
+		vAuraxClient = AuraxClient(service_id=settings.BotSettings.ps2ServiceID)
+
+		vPlayerChar = await vAuraxClient.get_by_name(AuraxPS2.Character, p_entry.ps2Name)
+
+		if vPlayerChar == None:
+			BUPrint.Debug("Provided character name not found! Resetting ps2name in entry.")
+			p_entry.ps2Name = ""
+			UserLibrary.SaveEntry(p_entry)
+			await vAuraxClient.close()
+			return False
+
+		vOutfitChar = await vPlayerChar.outfit_member()
+
+		if vOutfitChar == None:
+			BUPrint.Debug("Player not part of outfit.")
+			UserLibrary.SaveEntry(p_entry)
+			await vAuraxClient.close()
+		else:
+			vOutfit = await vOutfitChar.outfit()
+			p_entry.ps2Outfit = f"{vOutfit.name} {vOutfit.alias}"
+			p_entry.ps2OutfitJoinDate = datetime.fromtimestamp(vOutfitChar.member_since, tz=timezone.utc)
+			p_entry.ps2OutfitRank = vOutfitChar.rank
+
+		p_entry.ps2ID = vPlayerChar.id
+
+		await vAuraxClient.close()
+		UserLibrary.SaveEntry(p_entry)
+
+		if settings.UserLib.bEnforcePS2Rename and vPlayerChar != None:
+			discordMember = GetGuildNF(UserLibrary.botRef).get_member(p_entry.discordID)
+			renameStr = f"{vPlayerChar}"
+			if vOutfit != None:
+				renameStr += f" [{vOutfit.alias}]"
+
+			BUPrint.Info(f"{discordMember.name} provided PS2 character name in UserLib setup. Renaming user to: {renameStr}")
+			await discordMember.edit(nick=renameStr)
+
+		return True
+
+
+
+	def RemoveEntry(p_userID:int, p_removeSpecial:bool = False):
+		"""
+		# REMOVE ENTRY
+		Removes a user entry file from disk.
+		If removeSpecial is true, the special file is also removed if present.
+		"""
+		BUPrint.Info(f"Removing user library entry for user with ID: {p_userID}")
+		vPath = UserLibrary.GetEntryPath(p_userID)
+	
+		try:
+			os.remove(vPath)
+		except OSError as error:
+			BUPrint.LogErrorExc(f"Unable to remove file: {vPath}", error)
+
+		if not p_removeSpecial:
+			return
+
+		try:
+			vPath = vPath.replace(".bin", ".txt")
+			os.remove(vPath)
+		except OSError as error:
+			BUPrint.LogErrorExc(f"Unable to remove file: {vPath}", error)
+
+
+
+	def GetRecruitRequirements(p_entry:User, p_asBool:bool = False):
+		"""
+		# GET RECRUIT REQUIREMENTS
+		Almost functionally equivilant to QueryRecruit, except returns a string of the user requrements and doesn't do any modification.
+
+		### RETURN 
+		- `string` of the requirements; for human reading.
+		- `bool` if p_asBool is true:  returns True if user meets requirements.
+		"""
+		if not p_entry.bIsRecruit:
+			return "User is not a recruit."
+
+		vRequirementsMsg = ""
+		vGuild = GetGuildNF(UserLibrary.botRef)
+		if vGuild == None:
+			BUPrint.Debug("Unable to get guild?")
+			return "*ERROR: Unable to get guild.*" if not p_asBool else False
+		vDiscordUser = vGuild.get_member(p_entry.discordID)
+
+		if vDiscordUser == None:
+			BUPrint.Debug("User entry is for an invalid user.")
+			UserLibrary.RemoveEntry(p_entry)
+			return "INVALID USER!" if not p_asBool else False
+
+		bPromote = True
+		vPromoteRules = settings.UserLib.autoPromoteRules
+
+		if vPromoteRules.bAttendedMinimumEvents:			
+			if p_entry.eventsAttended < vPromoteRules.minimumEvents:
+				BUPrint.Debug("User failed events attended requirement.")
+				vRequirementsMsg += f"Needs to attend {vPromoteRules.minimumEvents-p_entry.eventsAttended} more event(s).\n"
+				bPromote = False
+			elif p_entry.eventsAttended >= vPromoteRules.minimumEvents and vPromoteRules.bEventsMustBePS2:
+				ps2Events = 0
+
+				session : Session
+				for session in p_entry.sessions:
+					if session.bIsPS2Event:
+						ps2Events += 1
+				if ps2Events < vPromoteRules.minimumEvents:
+					vRequirementsMsg += f"Needs to attend {vPromoteRules.minimumEvents-ps2Events} more Planetside 2 event(s).\n"
+					bPromote = False
+
+
+		vDateNow = datetime.now(tz=timezone.utc)
+		if vPromoteRules.bInDiscordForDuration:
+			requiredDate = vDiscordUser.joined_at + vPromoteRules.discordDuration
+
+			if vDateNow < requiredDate:
+				vDifference:timedelta = requiredDate - vDateNow
+				vRequirementsMsg += f"Needs to be in the discord for {vDifference.days} more day(s)."
+				bPromote = False
+
+		if vPromoteRules.bInOutfitForDuration:
+			if p_entry.ps2Outfit == "":
+					vRequirementsMsg += f"Needs to join the outfit!"
+					bPromote = False
+			else:
+				requiredDate = p_entry.ps2OutfitJoinDate + vPromoteRules.discordDuration
+				if vDateNow < requiredDate:
+					vDifference:timedelta = requiredDate - vDateNow
+					vRequirementsMsg += f"Needs to be in the outfit for {vDifference.days} more day(s)."
+					bPromote = False
+
+
+		if not bPromote:
+			BUPrint.Debug("Not promoting user.")
+			return vRequirementsMsg
+		
+		if p_asBool:
+			return bPromote
+		else:
+			return "Awaiting promotion!"
+
+
+
+	async def QueryRecruit(p_entry:User):
+		"""
+		# QUERY RECRUIT
+		Checks a recruits user entry.
+		If the user fulfils all the required criteria, they are promoted.
+
+		If validation is enabled, a request is sent to the admin chanel.
+
+		Returns a string to be used for administrative checking.
+		"""
+		if not settings.UserLib.bAutoPromoteEnabled:
+			BUPrint.Debug("Auto promotion is disabled.")
+			return
+
+		if not p_entry.bIsRecruit:
+			BUPrint.Debug("User is not a recruit.")
+			return
+
+		vGuild = GetGuildNF(UserLibrary.botRef)
+		vDiscordUser = vGuild.get_member(p_entry.discordID)
+
+		if vDiscordUser == None:
+			BUPrint.Debug("User entry is for an invalid user.")
+			UserLibrary.RemoveEntry(p_entry)
+			return
+
+		bPromote = True
+		vPromoteRules = settings.UserLib.autoPromoteRules
+
+		if vPromoteRules.bAttendedMinimumEvents:
+			
+			if p_entry.eventsAttended < vPromoteRules.minimumEvents:
+				BUPrint.Debug("User failed events attended requirement.")
+				bPromote = False
+			elif p_entry.eventsAttended >= vPromoteRules.minimumEvents and vPromoteRules.bEventsMustBePS2:
+				ps2Events = 0
+
+				session : Session
+				for session in p_entry.sessions:
+					if session.bIsPS2Event:
+						ps2Events += 1
+				if ps2Events < vPromoteRules.minimumEvents:
+					bPromote = False
+					
+		
+		vDateNow = datetime.now(tz=timezone.utc)
+		if vPromoteRules.bInDiscordForDuration:
+			requiredDate = vDiscordUser.joined_at + vPromoteRules.discordDuration
+
+			if vDateNow < requiredDate:
+				BUPrint.Debug("User failed discord date requirement.")
+				bPromote = False
+
+		if vPromoteRules.bInOutfitForDuration:
+			if p_entry.ps2Outfit == "":
+				BUPrint.Debug("User failed Outfit date requiremnt: They're not in an outfit!")
+				bPromote = False
+			else:
+				requiredDate = p_entry.ps2OutfitJoinDate + vPromoteRules.discordDuration
+				if vDateNow < requiredDate:
+					BUPrint.Debug("User failed discord date requirement.")
+					bPromote = False
+
+		if not bPromote:
+			BUPrint.Debug("Not promoting user.")
+			return
+
+		if settings.UserLib.bAutoPromoteEnabled:
+			vRequest = UserLib_RecruitValidationRequest( p_entry )
+			await vRequest.SendRequest()
+		else:
+			await UserLibrary.PromoteUser(vDiscordUser)
+
+
+
+	async def QueryAllRecruits():
+		recruitEntries = UserLibrary.GetRecruitEntries()
+
+		for entry in recruitEntries:
+			await UserLibrary.QueryRecruit(entry)
+
+
+
+	async def PromoteUser(p_member:discord.Member):
+		"""
+		# PROMOTE USER
+		Applies the specified promotion role and removes the recruit role.
+		"""
+
+		vRecruitRole:discord.Role = None
+		vPromotionRole:discord.Role = None
+		vGuild = UserLibrary.botRef.get_guild(int(settings.BotSettings.discordGuild))
+		
+		for role in vGuild.roles:
+			if vRecruitRole != None and vPromotionRole != None:
+				break
+
+			if role.id == settings.Roles.recruit:
+				vRecruitRole = role
+				continue
+
+			if role.id == settings.Roles.recruitPromotion:
+				vPromotionRole = role
+				continue
+
+
+		await p_member.remove_roles(vRecruitRole, reason="Promotion of user from recruit!")
+		await p_member.add_roles(vPromotionRole, reason="Promotion of user from recruit!")
+
+		# Update Library Entry:
+		userEntry = UserLibrary.LoadEntry(p_member.id)
+		userEntry.bIsRecruit = False
+		UserLibrary.SaveEntry(userEntry)
+
+		# Notify Admin channel:
+		vAdminChn = vGuild.get_channel( settings.Channels.botAdminID )
+		if vAdminChn != None:
+			await vAdminChn.send(f"User {p_member.display_name} was promoted to {vPromotionRole.name} ({vRecruitRole.name} removed)")
+
+
+	async def QuerySleeper(p_entry:User, p_sleeperRole:discord.Role):
+		"""# QUERY SLEEPER
+		Checks if the user meets/fails the sleeper requirements and sets/removes the sleeper role accordingly."""		
+		vGuild = GetGuildNF(UserLibrary.botRef)
+		vUser = vGuild.get_member(p_entry.discordID)
+
+
+		if settings.UserLib.sleeperRules.bSelfOutfitOnly:
+			userRoles = [role.id for role in vUser.roles]
+			
+			if settings.Roles.recruitPromotion not in userRoles:
+				BUPrint.Debug(f"User {vUser.display_name} not part of outfit, skipping.")
+				return
+
+
+		bApplySleeper = False
+
+		# Query rule: In recent event.
+		if settings.UserLib.sleeperRules.bInbRecentEvent:
+			# The earliest date at which an event is considered "recent" and thus sets the requirement.
+			requiredDate = datetime.now(tz=timezone.utc) - settings.UserLib.sleeperRules.mostRecentEvent
+			
+			if p_entry.sessions.__len__() != 0:
+				if p_entry.sessions[0].date < requiredDate:
+					bApplySleeper = True
+
+			# User not taken part in any sessions, check join date instead.
+			else:
+				if vUser.joined_at < requiredDate:
+					bApplySleeper = True
+
+
+
+		if bApplySleeper:
+			await vUser.add_roles(p_sleeperRole, reason="User failed sleeper check.  Applying sleeper role.")
+			BUPrint.Info(f"User: {vUser.display_name} is now asleep.")
+		
+		elif p_sleeperRole in vUser.roles:
+			await vUser.remove_roles(p_sleeperRole, reason="User awoken from sleeper.  Removing sleeper role.")
+			BUPrint.Info(f"User: {vUser.display_name} is now awake.")
+
+
+
+class LibraryViewer():
+	"""
+	# LIBRARY VIEWER
+	Class responsible for sending a viewer to see library information.
+
+	## PARAMETERS
+	- `p_userID`: the user ID to view.
+	- `p_isViewingSelf`: Whether the calling viewer is viewing themself.
+	"""
+	def __init__(self, p_userID:int, p_isViewingSelf:bool):
+		# Used to save a new entry.
+		self.userID = p_userID
+		# Used to determine if the configure button is shown.
+		self.bIsViewingSelf = p_isViewingSelf
+		# The User entry
+		self.userEntry:User = UserLibrary.LoadEntry(p_userID)
+		# Used to edit the viewer message.
+		self.viewerMsg:discord.Message = None
+		# Used to send the viewer controls
+		self.vewerConrolsMsg:discord.Message = None
+
+		# Stored to avoid unneeded repeated calls.
+		self.recruitRequirements:str = ""
+
+		self.page:LibraryViewPage = LibraryViewPage.general
+		self.multiPageNum = 0 # The number of the current page viewed.
+		self.listSelectMultiplier = 0 # this multiplier is used to offset the options.
+
+		BUPrint.Debug(f"User is viewing self: {self.bIsViewingSelf}")
+
+
+
+	async def UpdateViewer(self):
+		"""
+		# SEND VIEWER
+		Updates the viewer message.  
+		
+		This is the function to call when needing to refresh the embed/view.
+		"""
+		if self.viewerMsg != None:
+			await self.viewerMsg.edit(view=self.GenerateView(), embed=self.GenerateEmbed())
+		
+
+
+	async def SendViewer(self, p_interaction:discord.Interaction):
+		"""
+		# SEND VIEWER
+		Send the intitial viewer from the interaction call.
+		"""
+		await p_interaction.response.send_message(view=self.GenerateView(), embed=self.GenerateEmbed(), ephemeral=True)
+		self.viewerMsg = await p_interaction.original_response()
+
+
+
+	def GenerateView(self):
+		"""# GENERATE VIEW:
+		Creates and returns a view with button assignment appropriate for the current page/userData.
+
+		When needing to update the viewer, use `UpdateViewer`.
+		"""
+		vView = LibViewer_view(self)
+		btn_configure = LibViewerBtn_setup(self)
+		btn_inbox = LibViewerBtn_inbox(self)
+		btn_promoteReq = LibViewerBtn_recruitRequestPromotion(self)
+		btn_General = LibViewerBtn_general(self)
+		btn_Ps2 = LibViewerBtn_planetside2(self)
+		btn_sessions = LibViewerBtn_sessions(self)
+		btn_sessionPrev = LibViewerBtn_session_previous(self)
+		btn_sessionNext = LibViewerBtn_session_next(self)
+		btn_sessionSelect = LibViewerBtn_sessionSelector(self)
+
+		if self.bIsViewingSelf:
+			vView.add_item(btn_configure)
+			vView.add_item(btn_inbox)
+			if self.userEntry.bIsRecruit and not self.userEntry.bRecruitRequestedPromotion:
+				if UserLibrary.GetRecruitRequirements(self.userEntry, p_asBool=True):
+					vView.add_item(btn_promoteReq)
+		vView.add_item(btn_General)
+		vView.add_item(btn_Ps2)
+		vView.add_item(btn_sessions)
+
+		if self.page == LibraryViewPage.general:
+			btn_General.disabled = True
+			btn_sessionNext.disabled = True
+			btn_sessionPrev.disabled = True
+
+		elif self.page == LibraryViewPage.ps2Info:
+			btn_Ps2.disabled = True
+			btn_sessionNext.disabled = True
+			btn_sessionPrev.disabled = True
+
+		elif self.page == LibraryViewPage.sessions:
+			vView.add_item(btn_sessionPrev)
+			vView.add_item(btn_sessionNext)
+			vView.add_item(btn_sessionSelect)
+
+			btn_sessionPrev.disabled = bool(self.listSelectMultiplier == 0)
+			btn_sessionNext.disabled = bool( len(self.userEntry.sessions) < settings.UserLib.sessionMaxPerPage and ((1+self.listSelectMultiplier)*settings.UserLib.sessionMaxPerPage) < len(self.userEntry.sessions) + settings.UserLib.sessionMaxPerPage)
+
+		elif self.page == LibraryViewPage.individualSession:
+			vView.add_item(btn_sessionPrev)
+			vView.add_item(btn_sessionNext)
+			vView.add_item(btn_sessionSelect)
+			btn_sessionPrev.disabled = bool( self.multiPageNum == 0 )
+			# Remember to account for arrays starting at 0.
+			btn_sessionNext.disabled = bool(self.multiPageNum == len(self.userEntry.sessions)-1)
+
+		if len(self.userEntry.sessions) == 0:
+			btn_sessions.disabled = True
+			btn_sessionNext.disabled = True
+			btn_sessionPrev.disabled = True
+			btn_sessionSelect.disabled = True
+
+		if self.userEntry.ps2Name == "" or self.userEntry.ps2Name == None:
+			btn_Ps2.disabled = True
+
+
+		return vView
+
+
+
+	def GenerateEmbed(self):
+		"""
+		# GENERATE EMBED
+		Creates an embed using the current page setting and returns it.
+		"""
+		if self.page == LibraryViewPage.general:
+			return self.GenerateEmbed_General()
+
+		if self.page == LibraryViewPage.ps2Info:
+			return self.GenerateEmbed_ps2()
+
+		if self.page == LibraryViewPage.sessions:
+			return self.GenerateEmbed_sessionBrowser()
+
+		if self.page == LibraryViewPage.individualSession:
+			try:
+				return self.GenerateEmbed_session(self.userEntry.sessions[self.multiPageNum])
+			except IndexError:
+				BUPrint.LogError("Invalid session index given!")
+				return self.GenerateEmbed_General()
+
+		if self.page == LibraryViewPage.inbox:
+			return self.GenerateEmbed_inbox()
+
+
+
+	def GenerateEmbed_General(self):
+		vGuild = GetGuildNF(UserLibrary.botRef)
+		discordUser = vGuild.get_member(self.userID)
+		vEmbed = discord.Embed(
+			title=f"General Info for {discordUser.display_name}",
+			description=f"They joined the server {GetDiscordTime(discordUser.joined_at, DateFormat.Dynamic)}!"
+		)
+
+		if len(self.userEntry.topQuotes) != 0:
+			vQuotes = ""
+			for quote in self.userEntry.topQuotes:
+				vQuotes += f"{quote}\n"
+			vEmbed.add_field(
+				name="Top Quotes",
+				value=vQuotes,
+				inline=False
+			)
+
+		if self.userEntry.specialAbout != "":
+			vEmbed.add_field(
+				name="Special",
+				value=self.userEntry.specialAbout,
+				inline=False
+			)
+
+		if self.userEntry.aboutMe != "":
+			vEmbed.add_field(
+				name="About",
+				value=self.userEntry.aboutMe,
+				inline=False
+			)
+
+		if self.userEntry.birthday != None:
+			vEmbed.add_field(
+				name="Birthday",
+				value=f"{self.userEntry.birthday.day } / {self.userEntry.birthday.month}",
+				inline=True
+			)
+
+		if self.userEntry.bIsRecruit:
+			if self.recruitRequirements == "":
+				self.recruitRequirements = UserLibrary.GetRecruitRequirements(self.userEntry)
+
+			vEmbed.add_field(
+				name="Recruit!",
+				value=self.recruitRequirements,
+				inline=True
+			)
+
+		vEmbed.add_field(
+			name="Events Attended",
+			value=str(self.userEntry.eventsAttended),
+			inline=False
+			)
+
+		return vEmbed
+
+
+
+	def GenerateEmbed_inbox(self):
+		vEmbed = discord.Embed(title="Inbox", description=f"You have {len(self.userEntry.inbox)} messages")
+
+		if len(self.userEntry.inbox) == 0:
+			return vEmbed
+
+		for message in self.userEntry.inbox:
+			embedTitle = ""
+			if message.bIsWarning:
+				embedTitle = "WARNING: "
+			embedTitle += f"{GetDiscordTime(message.date, DateFormat.DateTimeShort)} | {message.title}"
+			
+			vEmbed.add_field(name=embedTitle, value=f"{message.adminContext}\n{message.message}", inline=False)
+
+		return vEmbed
+
+
+
+	def GenerateEmbed_ps2(self):
+		vEmbed = discord.Embed(title="Planetside 2 Information")
+
+		if self.userEntry.ps2Name != "" or self.userEntry.ps2Name != None:
+			BUPrint.Debug(f"PS2 Character Val: {self.userEntry.ps2Name}")
+			vEmbed.add_field(
+				name="PS2 Character",
+				value=self.userEntry.ps2Name,
+				inline=False
+			)
+
+			if self.userEntry.ps2Outfit != "" or self.userEntry.ps2Outfit != None:
+				BUPrint.Debug(f"Outfit Val: {self.userEntry.ps2Outfit}")
+				vEmbed.add_field(
+					name="PS2 Outfit",
+					value=self.userEntry.ps2Outfit,
+					inline=False
+					)
+			
+			if self.userEntry.ps2OutfitRank != "" or self.userEntry.ps2OutfitRank != None:
+				BUPrint.Debug(f"Outfit Rank val: {self.userEntry.ps2OutfitRank}")
+				vEmbed.add_field(
+					name="Outfit Rank",
+					value=self.userEntry.ps2OutfitRank,
+					inline=False
+				)
+
+		if len(self.userEntry.sessions) != 0:
+			displayStr = ""
+			session:Session
+			vIteration = 0
+			for session in self.userEntry.sessions:
+				if session.bIsPS2Event:
+					displayStr += f"{session.date.day}/{session.date.month}/{session.date.year} | {session.eventName}\n"
+				
+				vIteration += 1
+
+				if vIteration >= settings.UserLib.sessionPreviewMax:
+					break
+			
+			if displayStr != "":
+				vEmbed.add_field(
+					name="Tracked Sessions",
+					value=displayStr,
+					inline=False
+				)
+
+		return vEmbed
+
+
+	def GenerateEmbed_sessionBrowser(self):
+		"""
+		# GENERTAE EMBED: SESSION BROWSER
+		Generates an embed showing a browser like view of the users sessions.
+		"""
+		vEmbed = discord.Embed(
+			title="Tracked Sessions",
+			description=f"This user has attended {self.userEntry.eventsAttended}, missed {self.userEntry.eventsMissed}, and has {len(self.userEntry.sessions)} tracked sessions saved!"
+		)
+
+		vDisplayStr = ""
+		vIteration = 0
+		for session in self.userEntry.sessions[int(self.listSelectMultiplier * settings.UserLib.sessionMaxPerPage) : int((1+self.listSelectMultiplier)* settings.UserLib.sessionMaxPerPage)]:
+			vDisplayStr += f"{vIteration+1} | {session.date.day}/{session.date.month}/{session.date.year} | {session.eventName}"
+			if not session.bIsPS2Event:
+				vDisplayStr += " (Not PS2)\n"
+			else: vDisplayStr += "\n"
+			vIteration += 1
+
+		vEmbed.add_field(name="Tracked Sessions", value=vDisplayStr)
+
+		return vEmbed
+
+
+	def GenerateEmbed_session(self, p_session:Session):
+		"""
+		# GENERATE EMBED: Session
+		Generates an embed showing the stats from a session.
+		"""
+		vEmbed = discord.Embed(
+					title=f"{p_session.eventName}",
+					description=f"{GetDiscordTime(p_session.date, DateFormat.DateLonghand)}\nEvent lasted for {p_session.duration:.2f} hours"
+					)
+
+
+		if not p_session.bIsPS2Event:
+			vEmbed.add_field(name="NOTE:",value="This event is not for PS2, and thus has no statistics to show.")
+			
+			return vEmbed
+
+
+		if p_session.kda != None:
+			if p_session.kda.kills + p_session.kda.assists != 0 and p_session.kda.deathTotal != 0:
+				vEmbed.add_field(
+					name="KDA Ratio",
+					value=f"{((p_session.kda.kills + p_session.kda.assists) / p_session.kda.deathTotal):.2f}"
+				)
+
+			vEmbed.add_field(
+				name="Kills/Assists",
+				value=f"""Kills:{p_session.kda.kills}
+				Allies: {p_session.kda.killedAllies}
+				Squadmates: {p_session.kda.killedSquad}
+
+				Assists: {p_session.kda.assists}
+
+				Vehicle Takedowns: {p_session.kda.vehiclesDestroyed}
+				""".strip()
+			)
+
+			vEmbed.add_field(
+				name="Deaths",
+				value=f"""Total: {p_session.kda.deathTotal}
+				From enemies: {p_session.kda.deathByEnemies}
+				From allies: {p_session.kda.deathByAllies}
+				From Squad: {p_session.kda.deathBySquad}""".strip()
+			)
+
+		if p_session.medicData != None:
+			vEmbed.add_field(
+				name="Medic Stats",
+				value=f"""Heals: {p_session.medicData.heals}
+				Revives: {p_session.medicData.revives}
+				""".strip()
+			)
+
+		if p_session.engineerData != None:
+			vEmbed.add_field(
+				name="Engineer Stats",
+				value=f"""Vehicle Repairs: {p_session.engineerData.repairScore}
+				Resupplies: {p_session.engineerData.resupplyScore}
+				""".strip()
+			)
+
+
+		vEmbed.add_field(
+			name="Score",
+			value=str(p_session.score)
+		)
+
+
+		if len(p_session.funEvents) != 0:
+			vEventString = ""
+			for event in p_session.funEvents:
+				vEventString += f"{event}\n"
+
+			vEventString = vEventString[:1024]
+			vEmbed.add_field(
+				name="Fun Events",
+				value=vEventString,
+				inline=False
+			)
+
+		return vEmbed
+
+
+
+
+
+####### LIBRARY VIEWER BUTTONS & UI.VIEWER
+class LibViewer_btnViewInbox(discord.ui.Button):
+	def __init__(self, p_userID):
+		self.userID = p_userID
+		super().__init__( label="View inbox")
+
+	async def callback(self, p_interaction:discord.Interaction):
+		vViewer = LibraryViewer(self.userID, True)
+		vViewer.page = LibraryViewPage.inbox
+
+		await vViewer.SendViewer(p_interaction)
+			
+
+
+class LibViewer_view(discord.ui.View):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(timeout=180)
+
+	async def on_timeout(self):
+		try:
+			await self.vViewer.viewerMsg.delete()
+		except discord.errors.NotFound:
+			pass
+
+
+class LibViewerBtn_setup(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="Setup", row=0)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		await p_interaction.response.send_modal( LibViewer_ConfigureModal(self.vViewer) )
+
+
+
+class LibViewerBtn_recruitRequestPromotion(discord.ui.Button):
+	def __init__(self, p_viewer: LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="Request Promotion!", row=0, style=discord.ButtonStyle.green)
+
+	async def callback(self, p_interaction:discord.Interaction):
+		vRequest = UserLib_RecruitValidationRequest( self.vViewer.userEntry )
+		await vRequest.SendRequest()
+
+		self.vViewer.userEntry.bRecruitRequestedPromotion = True
+		UserLibrary.SaveEntry(self.vViewer.userEntry)
+		await self.vViewer.UpdateViewer()
+
+		await p_interaction.response.send_message("Promotion request sent!", ephemeral=True)
+
+
+class LibViewerBtn_general(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="General", row=1)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		self.vViewer.page = LibraryViewPage.general
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+class LibViewerBtn_planetside2(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="Planetside2", row=1)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		self.vViewer.page = LibraryViewPage.ps2Info
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+class LibViewerBtn_sessions(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="Sessions", row=1)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		self.vViewer.page = LibraryViewPage.sessions
+		self.vViewer.multiPageNum = 0
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+class LibViewerBtn_session_next(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label=">", row=1)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		# self.vViewer.page = LibraryViewPage.individualSession
+		if self.vViewer.page == LibraryViewPage.sessions:
+			self.vViewer.listSelectMultiplier += 1
+		else:
+			self.vViewer.multiPageNum += 1
+		
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+class LibViewerBtn_session_previous(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="<", row=1)
+
+	async def callback (self, p_interaction:discord.Interaction):
+		# self.vViewer.page = LibraryViewPage.individualSession
+		if self.vViewer.page == LibraryViewPage.sessions:
+			self.vViewer.listSelectMultiplier -= 1
+		else:
+			self.vViewer.multiPageNum -= 1		
+		
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+class LibViewerBtn_sessionSelector(discord.ui.Select):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(placeholder="Jump to a session page...")
+		vIteration = 0
+		for session in self.vViewer.userEntry.sessions[int(self.vViewer.listSelectMultiplier * settings.UserLib.sessionMaxPerPage) : int((1+self.vViewer.listSelectMultiplier)* settings.UserLib.sessionMaxPerPage)]:
+			self.add_option(
+				label=f"{vIteration+1} | {session.date.day}/{session.date.month}/{session.date.year} | {session.eventName}",
+				value=vIteration
+			)
+			vIteration += 1
+
+
+	async def callback (self, p_interaction:discord.Interaction):
+		self.vViewer.page = LibraryViewPage.individualSession
+		self.vViewer.multiPageNum = int(self.values[0])
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+
+class LibViewerBtn_inbox(discord.ui.Button):
+	def __init__(self, p_viewer:LibraryViewer):
+		self.vViewer = p_viewer
+		super().__init__(label="Inbox", row=0)
+
+
+	async def callback (self, p_interaction:discord.Interaction):
+		self.vViewer.page = LibraryViewPage.inbox
+		await self.vViewer.UpdateViewer()
+		await p_interaction.response.defer()
+
+
+#### LIB VIEWER CONFIGURE MODAL
+
+class LibViewer_ConfigureModal(discord.ui.Modal):
+	"""
+	# LIBRARY VIEWER: CONFIGURE MODAL
+	Takes one of two parameters; if an entry is specified with p_adminEditEntry, 
+	"""
+
+	txt_ps2Char = discord.ui.TextInput(
+		label="PS2 Character Name",
+		placeholder="YourPS2CharName",
+		required=False,
+		style=discord.TextStyle.short
+	)
+	txt_about = discord.ui.TextInput(
+		label="About You",
+		placeholder="Space to tell people about you, or just put something funny!",
+		required=False,
+		max_length=1024,
+		style=discord.TextStyle.paragraph
+	)
+	txt_birthday = discord.ui.TextInput(
+		label="Birth Date (year is optional & never shown)",
+		placeholder="DD/MM/YYYY (03/07/1991)",
+		required=False,
+		style=discord.TextStyle.short
+	)
+
+	txt_admin = discord.ui.TextInput(
+		label="Admin Commands",
+		placeholder="Enter commands here to change settings.",
+		required=False
+	)
+
+	txt_adminSpecial = discord.ui.TextInput(
+		label="Special",
+		placeholder="Non-User Editable special info, saved to text file...",
+		required=False,
+		style=discord.TextStyle.paragraph,
+		max_length=1024
+	)
+
+	def __init__(self, p_parentLibViewer:LibraryViewer = None, p_adminEditEntry:User = None):
+		super().__init__(title="CONFIGURE YOUR LIBRARY ENTRY")
+		self.parentViewer = p_parentLibViewer
+		self.vUserEntry:User = None
+		self.bIsAdminEdit = False
+
+		if p_adminEditEntry != None:
+			self.bIsAdminEdit = True
+			self.vUserEntry = p_adminEditEntry
+			self.parentViewer = None
+		else:
+			self.vUserEntry = p_parentLibViewer.userEntry
+			self.remove_item(self.txt_admin)
+			self.remove_item(self.txt_adminSpecial)
+
+		if self.vUserEntry.ps2Name != "" and not self.vUserEntry.settings.bLockPS2Char:
+			self.txt_ps2Char.placeholder = self.vUserEntry.ps2Name
+		elif self.vUserEntry.settings.bLockPS2Char:
+			self.remove_item(self.txt_ps2Char)
+		
+		if self.vUserEntry.aboutMe != "" and not self.vUserEntry.settings.bLockAbout:
+			self.txt_about.default = self.vUserEntry.aboutMe
+		elif self.vUserEntry.settings.bLockAbout:
+			self.remove_item(self.txt_about)
+
+		if self.vUserEntry.birthday != None:
+			self.txt_birthday.default = f"{self.vUserEntry.birthday.day}/{self.vUserEntry.birthday.month}"
+
+		if self.vUserEntry.specialAbout != "":
+			self.txt_adminSpecial.default = self.vUserEntry.specialAbout
+
+
+	async def on_submit(self, p_interaction:discord.Interaction):
+		vSuccessMessage = "Entry has been updated!"
+
+		if self.txt_adminSpecial.value != "":
+			self.vUserEntry.specialAbout = self.txt_adminSpecial.value
+
+		if self.txt_about.value != "":
+			self.vUserEntry.aboutMe = self.txt_about.value
+
+		if self.txt_birthday.value != "":
+			vDateStr = ""
+			vFormat = r"%d/%m/%Y"
+
+			try:
+				if self.txt_birthday.value.count("/") == 2:
+					BUPrint.Debug("User provided full date.")
+					vDate = datetime.strptime( self.txt_birthday.value , vFormat)
+					vDateStr = self.txt_birthday.value
+				else:
+					BUPrint.Debug("User provided partial date.")
+					vDateStr = f"{self.txt_birthday.value}/2000"
+					vDate = datetime.strptime( f"{self.txt_birthday.value}/2000" , vFormat)
+						
+					
+				BUPrint.Debug(f"Date Str: {vDateStr}")
+				self.vUserEntry.birthday = vDate
+
+			except ValueError:
+				BUPrint.Debug("User provided invalid date format.")
+				vSuccessMessage += f"\n\n{settings.Messages.invalidBirthdate}"
+
+
+		if self.txt_ps2Char.value != "":
+			if self.txt_ps2Char != self.vUserEntry.ps2Name:
+				self.vUserEntry.ps2Name = self.txt_ps2Char.value
+				await UserLibrary.PropogatePS2Info(self.vUserEntry)
+
+		if self.bIsAdminEdit:
+			self.ParseAdminCommands()
+			vSuccessMessage += f"\n\n**Settings:**\n"
+			vSuccessMessage += f"PS2 Character Locked: {self.vUserEntry.settings.bLockPS2Char}\n"
+			vSuccessMessage += f"AboutMe Locked: {self.vUserEntry.settings.bLockAbout}\n"
+			vSuccessMessage += f"Session History: {self.vUserEntry.settings.bTrackHistory}\n"
+			vSuccessMessage += f"User is Recruit: {self.vUserEntry.bIsRecruit}\n"
+
+			await p_interaction.response.send_message(vSuccessMessage, ephemeral=True)
+		else:
+			await self.parentViewer.UpdateViewer()
+			await p_interaction.response.send_message(vSuccessMessage, ephemeral=True)
+
+		UserLibrary.SaveEntry(self.vUserEntry)
+
+
+	def ParseAdminCommands(self):
+		"""
+		# PARSE ADMIN COMMANDS
+		Checks if any commands are found in the commands text field and sets their respective settings.
+		"""
+		adminCommands = self.txt_admin.value.lower()
+		# Manually set recruit status
+		if adminCommands.__contains__("isrecruit"):
+			self.vUserEntry.bIsRecruit = True
+		if adminCommands.__contains__("notrecruit"):
+			self.vUserEntry.bIsRecruit = False
+
+		# Set LockPS2 Character
+		if adminCommands.__contains__("lockps2"):
+			self.vUserEntry.settings.bLockPS2Char = True
+		if adminCommands.__contains__("openps2"):
+			self.vUserEntry.settings.bLockPS2Char = False
+	
+		# Set Lock About
+		if adminCommands.__contains__("lockabout"):
+			self.vUserEntry.settings.bLockAbout = True
+		if adminCommands.__contains__("openabout"):
+			self.vUserEntry.settings.bLockAbout = False
+		
+		# Set Tracking Sessions
+		if adminCommands.__contains__("trackhistory"):
+			self.vUserEntry.settings.bTrackHistory = True
+		if adminCommands.__contains__("nohistory"):
+			self.vUserEntry.settings.bTrackHistory = False
+			self.vUserEntry.sessions.clear()
+	
+		BUPrint.Debug(f"Settings: \n{self.vUserEntry.settings}")
+
+
+
+### RECRUIT ADMIN REQUEST
+
+class UserLib_RecruitValidationRequest():
+	"""
+	# USER LIBRARY: RECRUIT VALIDATION
+	A class that handles a validation request for a recruits promotion.
+	"""
+	botRef:commands.Bot
+
+	def __init__(self, p_userEntry:User):
+		self.userEntry = p_userEntry
+		self.requestMsg:discord.Message = None
+
+
+	async def SendRequest(self):
+		"""
+		# SEND REQUEST
+		Sends the request to an admin channel.
+		"""
+		vAdminChn = self.botRef.get_channel(settings.Channels.botAdminID)
+
+		if vAdminChn == None:
+			BUPrint.Info("Unable to get admin channel for promotion request!")
+			return
+
+		vView = discord.ui.View(timeout=None)
+		vView.add_item(RecruitValidationReq_btnAccept(self))
+
+		vUser = self.botRef.get_user(self.userEntry.discordID)
+
+		self.requestMsg = await vAdminChn.send(f"**RECRUIT PROMOTION VALIDATION**\nUser {vUser.mention} has met the set criteria and is ready to be promoted!", view=vView)
+
+
+class RecruitValidationReq_btnAccept(discord.ui.Button):
+	def __init__(self, p_parentRequest:UserLib_RecruitValidationRequest):
+		self.parent = p_parentRequest
+		super().__init__(label="Promote!", style=discord.ButtonStyle.green)
+
+	async def callback(self, p_interaction:discord.Interaction):
+		vUser = p_interaction.guild.get_member(self.parent.userEntry.discordID)
+		
+		await UserLibrary.PromoteUser( vUser )
+
+		await self.parent.requestMsg.delete()
+
+		await p_interaction.response.send_message(f"Done!", ephemeral=True)


### PR DESCRIPTION
# Adds
- User Library Cog
- User Library Admin cog

# Breakdown
UserLibrary is the bots database of users.
- Holds information about a users PS2 character (ID, outfit, name).
- Capable of holding other data, currently: birthdate, mini `about me`; an admin editable only `about me` like text; saved sessions
- Functional data: bool for- is a recruit, last session- for when session saving is disabled.
- Can apply a sleeper/inactive role for users who fail set requirements (currently just last session attended within x months)
- Provides a method for sending administrative messages via an inbox system; self contained in the event a user has disabled allowing DM's.
- Provides a viewer allowing someone to view another users/their own entry.

# Admin Cog breakdown
- Adds a command to generate missing entries.  Has a flag to only generate missing entries for outfit only, only people specified as bot admin can run this command with the outfit only set to False.  Entries are created barebones and just have the users discordID.
- Adds a command to edit a users entry: brings up the same edit modal as a normal user but with additional fields- special text and arguments, allowing an admin to set the UserLib options for that persons entry (see the wiki for options).
- Adds context menu options for messages, and user, allowing an admin to send an inbox warning to the user.